### PR TITLE
ci(signing): Add static debug APK signing

### DIFF
--- a/.github/workflows/Action.yaml
+++ b/.github/workflows/Action.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   build-debug:
     runs-on: ubuntu-latest
+    environment: release
 
     steps:
       - name: Checkout
@@ -26,9 +27,18 @@ jobs:
       - name: Grant gradlew permission
         run: chmod +x ./gradlew
 
+      - name: Prepare Environment Variables
+        run: echo "$DEBUG_KEYSTORE_BASE64" | base64 --decode > app/debug-keystore.jks
+        env:
+          DEBUG_KEYSTORE_BASE64: ${{ secrets.DEBUG_KEYSTORE_BASE64 }}
+
       # 组装 debug APK
       - name: Build debug APK
         run: ./gradlew assembleDebug
+        env:
+          DEBUG_STORE_PASSWORD: ${{ secrets.DEBUG_STORE_PASSWORD }}
+          DEBUG_KEY_ALIAS: ${{ secrets.DEBUG_KEY_ALIAS }}
+          DEBUG_KEY_PASSWORD: ${{ secrets.DEBUG_KEY_PASSWORD }}
 
       # 上传给 Actions 页面下载查看
       - name: Upload debug APK

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,6 +13,15 @@ android {
         version = release(36)
     }
 
+    signingConfigs {
+        getByName("debug") {
+            storeFile = file(System.getenv("DEBUG_STORE_FILE") ?: "debug-keystore.jks")
+            storePassword = System.getenv("DEBUG_STORE_PASSWORD") ?: "android"
+            keyAlias = System.getenv("DEBUG_KEY_ALIAS") ?: "androiddebugkey"
+            keyPassword = System.getenv("DEBUG_KEY_PASSWORD") ?: "android"
+        }
+    }
+
     defaultConfig {
         applicationId = "com.baidaidai.rootless_store"
         minSdk = 26
@@ -24,6 +33,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            signingConfig = signingConfigs.getByName("debug")
+        }
         release {
             isMinifyEnabled = false
             proguardFiles(


### PR DESCRIPTION
Configure the debug build to use a static keystore from environment variables. Decode the debug keystore in GitHub Actions and pass signing secrets into the debug APK build.