### PR TITLE
fix(source): Handle authentication access control results

### DIFF
--- a/app/src/main/java/com/baidaidai/rootless_store/data/source/gateway/PluginSourceGatewayImpl.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/data/source/gateway/PluginSourceGatewayImpl.kt
@@ -8,7 +8,7 @@ import com.baidaidai.rootless_store.data.source.remote.dto.PluginSourceInfoDTO
 import com.baidaidai.rootless_store.domain.source.gateway.PluginSourceGateway
 import com.baidaidai.rootless_store.domain.source.model.PluginSourceInfo
 import com.baidaidai.rootless_store.domain.source.model.PluginSourceAuthFormInput
-import com.baidaidai.rootless_store.domain.source.model.PluginSourceAuthenticationInfo
+import com.baidaidai.rootless_store.domain.source.model.PluginSourceAuthenticationResult
 import io.ktor.client.call.body
 import javax.inject.Inject
 
@@ -24,11 +24,37 @@ class PluginSourceGatewayImpl @Inject constructor(
         return pluginSource
     }
 
-    suspend fun getPluginSourceAuthenticationInfo(pluginSourceAuthFormInput: PluginSourceAuthFormInput): PluginSourceAuthenticationInfo {
-        val ktorResponse = pluginSourceAPI.getPluginSourceAuthenticationInfo(pluginSourceAuthFormInput)
-        val pluginSourceAuthenticationInfoDTO = ktorResponse.body<PluginSourceAuthenticationInfoDTO>()  // Convert JSON to DTO
+    suspend fun getPluginSourceAuthenticationResult(pluginSourceAuthFormInput: PluginSourceAuthFormInput): PluginSourceAuthenticationResult {
+        return try {
+            val ktorResponse = pluginSourceAPI.getPluginSourceAuthenticationInfo(pluginSourceAuthFormInput)
+            val httpStatusCode = ktorResponse.status.value
 
-        val pluginSourceAuthenticationInfo = pluginSourceAuthenticationInfoDTO.toPluginSourceAuthenticationInfo()
-        return pluginSourceAuthenticationInfo
+            when(httpStatusCode){
+                200 -> {
+                    val pluginSourceAuthenticationInfoDTO = ktorResponse.body<PluginSourceAuthenticationInfoDTO>()  // Convert JSON to DTO
+                    val pluginSourceAuthenticationInfo = pluginSourceAuthenticationInfoDTO.toPluginSourceAuthenticationInfo()
+
+                    PluginSourceAuthenticationResult.Success(
+                        userName = pluginSourceAuthenticationInfo.userName,
+                        userAccessToken = pluginSourceAuthenticationInfo.userAccessToken
+                    )
+                }
+
+                401 -> {
+                    PluginSourceAuthenticationResult.AccessDenied(
+                        httpStatusCode = httpStatusCode,
+                        errorMessage = "The server denied the access"
+                    )
+                }
+
+                403 -> {
+                    PluginSourceAuthenticationResult.AccessDenied(
+                        httpStatusCode = httpStatusCode,
+                        errorMessage = "Permission denied"
+                    )
+                }
+                else -> { PluginSourceAuthenticationResult.ServerError }
+            }
+        }catch (error: Throwable){ PluginSourceAuthenticationResult.NetworkError }
     }
 }

--- a/app/src/main/java/com/baidaidai/rootless_store/data/source/repository/PluginSourceRepositoryImpl.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/data/source/repository/PluginSourceRepositoryImpl.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import com.baidaidai.rootless_store.data.source.mapper.PluginSourceMapper.toPluginSourceInfo
 import com.baidaidai.rootless_store.domain.source.model.PluginSourceAuthFormInput
+import com.baidaidai.rootless_store.domain.source.model.PluginSourceAuthenticationResult
 import kotlinx.coroutines.flow.map
 
 class PluginSourceRepositoryImpl @Inject constructor(
@@ -64,26 +65,46 @@ class PluginSourceRepositoryImpl @Inject constructor(
         try{
 
             val pluginSource = pluginSourceGatewayImpl.getPluginSource(sourceRemoteEndpoint = pluginSourceAuthFormInput.sourceRemoteEndpoint)
-            val sourceAuthenticationInfo = pluginSourceGatewayImpl.getPluginSourceAuthenticationInfo(pluginSourceAuthFormInput)
+            val sourceAuthenticationResult = pluginSourceGatewayImpl.getPluginSourceAuthenticationResult(pluginSourceAuthFormInput)
 
             /**
              * 验证，打断异常会话
              */
-            if (sourceAuthenticationInfo.userAccessToken == ""){
-                return PluginSourceEvent.SourceError(
-                    errorMessage = "Verification failed",
-                    errorCause = ""
-                )
+            return when(sourceAuthenticationResult){
+                is PluginSourceAuthenticationResult.Success -> {
+                    val pluginSourceEntity = PluginSourceEntity
+                        .fromPluginSourceLocal(pluginSource)
+                        .copy(userAccessToken = sourceAuthenticationResult.userAccessToken)
+
+                    pluginSourceDAO.insertOnePluginSource(pluginSourceEntity)
+
+                    PluginSourceEvent.Success
+                }
+                is PluginSourceAuthenticationResult.AccessDenied -> {
+                    PluginSourceEvent.SourceError(
+                        errorMessage = "Verification failed",
+                        errorCause = sourceAuthenticationResult.errorMessage
+                    )
+                }
+                is PluginSourceAuthenticationResult.ServerError -> {
+                    PluginSourceEvent.SourceError(
+                        errorMessage = "Server error",
+                        errorCause = "Please try again later"
+                    )
+                }
+                is PluginSourceAuthenticationResult.NetworkError -> {
+                    PluginSourceEvent.SourceError(
+                        errorMessage = "Network error",
+                        errorCause = "Please try again later"
+                    )
+                }
+                else -> {
+                    PluginSourceEvent.SourceError(
+                        errorMessage = "不可能的错误",
+                        errorCause = "你猜是什么错误呢？"
+                    )
+                }
             }
-
-
-            val pluginSourceEntity = PluginSourceEntity
-                .fromPluginSourceLocal(pluginSource)
-                .copy(userAccessToken = sourceAuthenticationInfo.userAccessToken)
-
-            pluginSourceDAO.insertOnePluginSource(pluginSourceEntity)
-
-            return PluginSourceEvent.Success
 
         }catch (error: Throwable){
 

--- a/app/src/main/java/com/baidaidai/rootless_store/domain/source/model/PluginSourceAuthenticationResult.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/domain/source/model/PluginSourceAuthenticationResult.kt
@@ -1,0 +1,17 @@
+package com.baidaidai.rootless_store.domain.source.model
+
+interface PluginSourceAuthenticationResult {
+    data class Success(
+        val userName: String,
+        val userAccessToken: String
+    ) : PluginSourceAuthenticationResult
+
+    data class AccessDenied(
+        val httpStatusCode: Int,
+        val errorMessage: String
+    ) : PluginSourceAuthenticationResult
+
+    data object NetworkError : PluginSourceAuthenticationResult
+
+    data object ServerError: PluginSourceAuthenticationResult
+}


### PR DESCRIPTION
Return explicit authentication results for success, access denial, network errors, and server errors. Map private source authentication results into source events before saving authenticated sources.