### PR TITLE
feat(plugin): Add hold actions for local plugin cards

### DIFF
--- a/app/src/main/java/com/baidaidai/rootless_store/ui/components/pluginsScreen/PluginActionContainer.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/components/pluginsScreen/PluginActionContainer.kt
@@ -1,0 +1,116 @@
+package com.baidaidai.rootless_store.ui.components.pluginsScreen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.baidaidai.rootless_store.R
+
+@Composable
+fun PluginActionContainer(
+    modifier: Modifier = Modifier,
+    onShareButtonClick: ()-> Unit = {},
+    onBackButtonClick: ()-> Unit = {},
+    onDeleteButtonClick: ()-> Unit = {},
+){
+
+    val shareButtonColors = IconButtonColors(
+        containerColor = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
+        disabledContainerColor = MaterialTheme.colorScheme.primary,
+        disabledContentColor = MaterialTheme.colorScheme.onPrimary
+    )
+
+    val backButtonColors = IconButtonColors(
+        containerColor = MaterialTheme.colorScheme.secondary,
+        contentColor = MaterialTheme.colorScheme.onSecondary,
+        disabledContainerColor = MaterialTheme.colorScheme.secondary,
+        disabledContentColor = MaterialTheme.colorScheme.onSecondary
+    )
+
+    val deleteButtonColors = IconButtonColors(
+        containerColor = MaterialTheme.colorScheme.error,
+        contentColor = MaterialTheme.colorScheme.onError,
+        disabledContainerColor = MaterialTheme.colorScheme.error,
+        disabledContentColor = MaterialTheme.colorScheme.onError
+    )
+
+    Surface(
+        modifier = modifier
+            .clip(MaterialTheme.shapes.large)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceAround,
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    color = MaterialTheme.colorScheme.surfaceContainer
+                )
+        ) {
+
+            IconButton(
+                onClick = onShareButtonClick,
+                colors = shareButtonColors,
+                modifier = Modifier
+                    .size(56.dp)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.material_symbols_ios_share),
+                    contentDescription = "Share"
+                )
+            }
+
+            IconButton(
+                onClick = onBackButtonClick,
+                colors = backButtonColors,
+                modifier = Modifier
+                    .size(56.dp)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.material_symbols_undo),
+                    contentDescription = "Share"
+                )
+            }
+
+            IconButton(
+                onClick = onDeleteButtonClick,
+                colors = deleteButtonColors,
+                modifier = Modifier
+                    .size(56.dp)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.material_symbols_delete),
+                    contentDescription = "Share"
+                )
+            }
+
+        }
+    }
+
+}
+
+@PreviewLightDark
+@Composable
+private fun _preview_() {
+    PluginActionContainer(
+        modifier = Modifier
+            .size(
+                width = 300.dp,
+                height = 200.dp
+            )
+    )
+}

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/components/pluginsScreen/PluginInfoContainerLocal.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/components/pluginsScreen/PluginInfoContainerLocal.kt
@@ -1,21 +1,15 @@
 package com.baidaidai.rootless_store.ui.components.pluginsScreen
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Badge
-import androidx.compose.material3.BadgedBox
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
@@ -24,9 +18,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import com.baidaidai.rootless_store.R
@@ -36,114 +31,96 @@ import com.baidaidai.rootless_store.domain.plugin.manifest.PluginManifestRoom
 
 @Composable
 fun PluginInfoContainerLocal(
-    badgeShowState: Boolean = true,
     pluginManifest: PluginManifestRoom,
+    onCardSizeChanged: (intSize: IntSize)-> Unit = {},
     onSwitchClick: ()-> Unit,
-    onBadgeClick:()-> Unit,
-    onCardClick:()-> Unit,
+    onCardClick: ()-> Unit,
+    onCardLongClick: ()-> Unit = {}
 ){
-    BadgedBox(
-        badge = {
-            if (badgeShowState){
-                Badge(
+    Column(
+        modifier = Modifier
+            .clip(MaterialTheme.shapes.large)
+            .combinedClickable(
+                onClick = { onCardClick() },
+                onLongClick = { onCardLongClick() }
+            )
+            .onSizeChanged { onCardSizeChanged(it) }
+        ,
+    ) {
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            modifier = Modifier
+                .clip(MaterialTheme.shapes.extraSmall)
+        ){
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp)
+                ,
+                verticalAlignment = Alignment.CenterVertically
+            ){
+                DynamicPluginIcon(
+                    iconUri = pluginManifest.iconURI?.toUri(),
+                    contentDescription = "Plugin Icon",
                     modifier = Modifier
-                        .size(16.dp)
+                        .clip(CircleShape)
+                )
+                Spacer(
+                    modifier = Modifier
+                        .width(12.dp)
+                )
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
                 ){
-                    IconButton(
-                        onClick = { onBadgeClick() }
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.outline_close_24),
-                            contentDescription = stringResource(R.string.plugin_screen_info_container_local_delete_button_content_description),
-                            modifier = Modifier
-                                .fillMaxSize()
-                        )
-                    }
+                    Text(
+                        text = pluginManifest.pluginRenderingName,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        text = icuString(
+                            R.string.plugin_screen_info_container_local_version,
+                            mapOf("version" to pluginManifest.installedVersion)
+                        ),
+                        style = MaterialTheme.typography.labelMedium
+                    )
                 }
+                Switch(
+                    checked = pluginManifest.enabled,
+                    onCheckedChange = { onSwitchClick() }
+                )
             }
         }
-    ) {
-        Column(
+        Spacer(
             modifier = Modifier
-                .clip(MaterialTheme.shapes.large)
-                .clickable{ onCardClick() }
-            ,
-        ) {
-            Surface(
-                color = MaterialTheme.colorScheme.surfaceContainer,
+                .height(2.dp)
+        )
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            modifier = Modifier
+                .clip(MaterialTheme.shapes.extraSmall)
+        ){
+            Column(
+                verticalArrangement = Arrangement.spacedBy(6.dp),
                 modifier = Modifier
-                    .clip(MaterialTheme.shapes.extraSmall)
-            ){
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(24.dp)
-                    ,
-                    verticalAlignment = Alignment.CenterVertically
-                ){
-                    DynamicPluginIcon(
-                        iconUri = pluginManifest.iconURI?.toUri(),
-                        contentDescription = "Plugin Icon",
-                        modifier = Modifier
-                            .clip(CircleShape)
-                    )
-                    Spacer(
-                        modifier = Modifier
-                            .width(12.dp)
-                    )
-                    Column(
-                        modifier = Modifier
-                            .weight(1f)
-                    ){
-                        Text(
-                            text = pluginManifest.pluginRenderingName,
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        Text(
-                            text = icuString(
-                                R.string.plugin_screen_info_container_local_version,
-                                mapOf("version" to pluginManifest.installedVersion)
-                            ),
-                            style = MaterialTheme.typography.labelMedium
-                        )
-                    }
-                    Switch(
-                        checked = pluginManifest.enabled,
-                        onCheckedChange = { onSwitchClick() }
-                    )
-                }
-            }
-            Spacer(
-                modifier = Modifier
-                    .height(2.dp)
-            )
-            Surface(
-                color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                modifier = Modifier
-                    .clip(MaterialTheme.shapes.extraSmall)
-            ){
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(6.dp),
-                    modifier = Modifier
-                        .padding(24.dp)
-                ) {
-                    PluginInfoRow(
-                        label = stringResource(R.string.plugin_screen_info_container_local_author_label),
-                        value = pluginManifest.author
-                    )
-                    PluginInfoRow(
-                        label = stringResource(R.string.plugin_screen_info_container_local_source_label),
-                        value = pluginManifest.source.toString()
-                    )
-                    PluginInfoRow(
-                        label = stringResource(R.string.plugin_screen_info_container_local_state_label),
-                        value = pluginManifest.state.toString()
-                    )
-                    PluginInfoRow(
-                        label = stringResource(R.string.plugin_screen_info_container_local_required_label),
-                        value = pluginManifest.requiredEnvironment.toString()
-                    )
-                }
+                    .padding(24.dp)
+            ) {
+                PluginInfoRow(
+                    label = stringResource(R.string.plugin_screen_info_container_local_author_label),
+                    value = pluginManifest.author
+                )
+                PluginInfoRow(
+                    label = stringResource(R.string.plugin_screen_info_container_local_source_label),
+                    value = pluginManifest.source.toString()
+                )
+                PluginInfoRow(
+                    label = stringResource(R.string.plugin_screen_info_container_local_state_label),
+                    value = pluginManifest.state.toString()
+                )
+                PluginInfoRow(
+                    label = stringResource(R.string.plugin_screen_info_container_local_required_label),
+                    value = pluginManifest.requiredEnvironment.toString()
+                )
             }
         }
     }
@@ -151,114 +128,96 @@ fun PluginInfoContainerLocal(
 
 @Composable
 fun PluginInfoContainerLocal(
-    badgeShowState: Boolean = true,
     environmentManifest: EnvironmentManifestRoom,
+    onCardSizeChanged: (intSize: IntSize)-> Unit = {},
     onSwitchClick: ()-> Unit,
-    onBadgeClick:()-> Unit,
-    onCardClick:()-> Unit,
+    onCardClick:()-> Unit = {},
+    onCardLongClick: ()-> Unit = {}
 ){
-    BadgedBox(
-        badge = {
-            if (badgeShowState){
-                Badge(
+    Column(
+        modifier = Modifier
+            .clip(MaterialTheme.shapes.large)
+            .combinedClickable(
+                onClick = { onCardClick() },
+                onLongClick = { onCardLongClick() }
+            )
+            .onSizeChanged { onCardSizeChanged(it) }
+        ,
+    ) {
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainer,
+            modifier = Modifier
+                .clip(MaterialTheme.shapes.extraSmall)
+        ){
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp)
+                ,
+                verticalAlignment = Alignment.CenterVertically
+            ){
+                DynamicPluginIcon(
+                    iconUri = environmentManifest.iconURI?.toUri(),
+                    contentDescription = "Plugin Icon",
                     modifier = Modifier
-                        .size(16.dp)
+                        .clip(CircleShape)
+                )
+                Spacer(
+                    modifier = Modifier
+                        .width(12.dp)
+                )
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
                 ){
-                    IconButton(
-                        onClick = { onBadgeClick() }
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.outline_close_24),
-                            contentDescription = stringResource(R.string.plugin_screen_info_container_local_delete_button_content_description),
-                            modifier = Modifier
-                                .fillMaxSize()
-                        )
-                    }
+                    Text(
+                        text = environmentManifest.environmentRenderingName,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        text = icuString(
+                            R.string.plugin_screen_info_container_local_version,
+                            mapOf("version" to environmentManifest.installedVersion)
+                        ),
+                        style = MaterialTheme.typography.labelMedium
+                    )
                 }
+                Switch(
+                    checked = environmentManifest.enabled,
+                    onCheckedChange = { onSwitchClick() }
+                )
             }
         }
-    ) {
-        Column(
+        Spacer(
             modifier = Modifier
-                .clip(MaterialTheme.shapes.large)
-                .clickable{ onCardClick() }
-            ,
-        ) {
-            Surface(
-                color = MaterialTheme.colorScheme.surfaceContainer,
+                .height(2.dp)
+        )
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            modifier = Modifier
+                .clip(MaterialTheme.shapes.extraSmall)
+        ){
+            Column(
+                verticalArrangement = Arrangement.spacedBy(6.dp),
                 modifier = Modifier
-                    .clip(MaterialTheme.shapes.extraSmall)
-            ){
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(24.dp)
-                    ,
-                    verticalAlignment = Alignment.CenterVertically
-                ){
-                    DynamicPluginIcon(
-                        iconUri = environmentManifest.iconURI?.toUri(),
-                        contentDescription = "Plugin Icon",
-                        modifier = Modifier
-                            .clip(CircleShape)
-                    )
-                    Spacer(
-                        modifier = Modifier
-                            .width(12.dp)
-                    )
-                    Column(
-                        modifier = Modifier
-                        .weight(1f)
-                    ){
-                        Text(
-                            text = environmentManifest.environmentRenderingName,
-                            style = MaterialTheme.typography.titleMedium
-                        )
-                        Text(
-                            text = icuString(
-                                R.string.plugin_screen_info_container_local_version,
-                                mapOf("version" to environmentManifest.installedVersion)
-                            ),
-                            style = MaterialTheme.typography.labelMedium
-                        )
-                    }
-                    Switch(
-                        checked = environmentManifest.enabled,
-                        onCheckedChange = { onSwitchClick() }
-                    )
-                }
-            }
-            Spacer(
-                modifier = Modifier
-                    .height(2.dp)
-            )
-            Surface(
-                color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                modifier = Modifier
-                    .clip(MaterialTheme.shapes.extraSmall)
-            ){
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(6.dp),
-                    modifier = Modifier
-                        .padding(24.dp)
-                ) {
-                    PluginInfoRow(
-                        label = stringResource(R.string.plugin_screen_info_container_local_author_label),
-                        value = environmentManifest.author
-                    )
-                    PluginInfoRow(
-                        label = stringResource(R.string.plugin_screen_info_container_local_source_label),
-                        value = environmentManifest.source.toString()
-                    )
-                    PluginInfoRow(
-                        label = stringResource(R.string.plugin_screen_info_container_local_state_label),
-                        value = environmentManifest.state.toString()
-                    )
-                    PluginInfoRow(
-                        label = stringResource(R.string.plugin_screen_info_container_local_required_label),
-                        value = environmentManifest.requiredEnvironment.toString()
-                    )
-                }
+                    .padding(24.dp)
+            ) {
+                PluginInfoRow(
+                    label = stringResource(R.string.plugin_screen_info_container_local_author_label),
+                    value = environmentManifest.author
+                )
+                PluginInfoRow(
+                    label = stringResource(R.string.plugin_screen_info_container_local_source_label),
+                    value = environmentManifest.source.toString()
+                )
+                PluginInfoRow(
+                    label = stringResource(R.string.plugin_screen_info_container_local_state_label),
+                    value = environmentManifest.state.toString()
+                )
+                PluginInfoRow(
+                    label = stringResource(R.string.plugin_screen_info_container_local_required_label),
+                    value = environmentManifest.requiredEnvironment.toString()
+                )
             }
         }
     }
@@ -301,6 +260,7 @@ private fun _PluginInfosContainerPreview_(){
     PluginInfoContainerLocal(
         pluginManifest = PluginManifestRoom._testOnly_,
         onSwitchClick = {},
-        onBadgeClick = {}
-    ){}
+        onCardClick = {},
+        onCardLongClick = {}
+    )
 }

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/screens/EnvironmentScreen.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/screens/EnvironmentScreen.kt
@@ -3,12 +3,20 @@ package com.baidaidai.rootless_store.ui.screens
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import com.baidaidai.rootless_store.domain.environment.manifest.EnvironmentManifestRoom
+import com.baidaidai.rootless_store.ui.components.pluginsScreen.PluginActionContainer
 import com.baidaidai.rootless_store.ui.components.pluginsScreen.PluginInfoContainerLocal
 import com.baidaidai.rootless_store.ui.model.RootLessStorePluginScreenViewModel
 
@@ -18,6 +26,9 @@ fun EnvironmentScreen(
     renderingList: List<EnvironmentManifestRoom>,
     pluginScreenViewModel: RootLessStorePluginScreenViewModel,
 ){
+
+    val density = LocalDensity.current
+
     LazyColumn(
         modifier = Modifier
             .fillMaxSize(),
@@ -27,21 +38,42 @@ fun EnvironmentScreen(
             horizontal = 15.dp
         )
     ) {
-        items(renderingList){
-            PluginInfoContainerLocal(
-                environmentManifest = it,
-                onSwitchClick = {
-                    pluginScreenViewModel.setEnvironmentEnabled(
-                        environmentID = it.environmentID,
-                        environmentEnabledStatus = !it.enabled
-                    )
-                },
-                onBadgeClick = {
-                    pluginScreenViewModel.uninstallEnvironment(it)
-                },
-                onCardClick = {},
-                badgeShowState = badgeShowState
-            )
+        items(
+            items = renderingList,
+            key = { environmentManifestRoom -> environmentManifestRoom.environmentID }
+        ){ environmentManifestRoom ->
+
+            var actionCanSee by remember { mutableStateOf(false) }
+            var cardSize by remember { mutableStateOf(IntSize.Zero) }
+
+            if (actionCanSee){
+
+                PluginActionContainer(
+                    onShareButtonClick = {},
+                    onDeleteButtonClick = { pluginScreenViewModel.uninstallEnvironment(environmentManifestRoom) },
+                    onBackButtonClick = { actionCanSee = !actionCanSee },
+                    modifier = Modifier
+                        .size(
+                            width = with(density) { cardSize.width.toDp() },
+                            height = with(density) { cardSize.height.toDp() }
+                        )
+                )
+
+            }else{
+
+                PluginInfoContainerLocal(
+                    environmentManifest = environmentManifestRoom,
+                    onSwitchClick = {
+                        pluginScreenViewModel.setEnvironmentEnabled(
+                            environmentID = environmentManifestRoom.environmentID,
+                            environmentEnabledStatus = !environmentManifestRoom.enabled
+                        )
+                    },
+                    onCardLongClick = { actionCanSee = !actionCanSee },
+                    onCardSizeChanged = { cardSize = it },
+                )
+
+            }
         }
     }
 }

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/screens/PluginScreen.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/screens/PluginScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.SecondaryTabRow
@@ -15,16 +16,21 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.baidaidai.rootless_store.R
 import com.baidaidai.rootless_store.ui.model.RootLessStorePluginScreenViewModel
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.IntSize
 import com.baidaidai.rootless_store.domain.plugin.manifest.PluginManifestRoom
+import com.baidaidai.rootless_store.ui.components.pluginsScreen.PluginActionContainer
 import com.baidaidai.rootless_store.ui.components.pluginsScreen.PluginInfoContainerLocal
 import kotlinx.coroutines.launch
 
@@ -32,7 +38,6 @@ import kotlinx.coroutines.launch
 fun RootlessStorePluginScreenContainer(
     contentPadding: PaddingValues,
     pluginScreenViewModel: RootLessStorePluginScreenViewModel,
-//    executeScreenViewModel: RootLessStoreExecuteScreenViewModel,
     navigateToExecuteScreen: (pluginID: String,isExecutePlugin: Boolean)-> Unit,
     onAbortOnePlugin:suspend (pluginID: String) -> Unit
 ){
@@ -77,7 +82,6 @@ fun RootlessStorePluginScreenContainer(
                 PluginScreen(
                     badgeShowState = badgeShowState,
                     renderingList = pluginInfoList,
-//                    executeScreenViewModel = executeScreenViewModel,
                     pluginScreenViewModel = pluginScreenViewModel,
                     navigateToExecuteScreen = navigateToExecuteScreen,
                     onAbortOnePlugin = onAbortOnePlugin
@@ -98,12 +102,12 @@ fun RootlessStorePluginScreenContainer(
 fun PluginScreen(
     badgeShowState: Boolean,
     renderingList: List<PluginManifestRoom>,
-//    executeScreenViewModel: RootLessStoreExecuteScreenViewModel,
     pluginScreenViewModel: RootLessStorePluginScreenViewModel,
     navigateToExecuteScreen: (pluginID: String,isExecutePlugin: Boolean)-> Unit,
     onAbortOnePlugin: suspend (pluginID: String) -> Unit
 ){
     val coroutineScope = rememberCoroutineScope()
+    val density = LocalDensity.current
 
     LazyColumn(
         modifier = Modifier
@@ -114,33 +118,56 @@ fun PluginScreen(
             horizontal = 15.dp
         )
     ) {
-        items(renderingList){
-            PluginInfoContainerLocal(
-                pluginManifest = it,
-                onSwitchClick = {
-                    pluginScreenViewModel.setPluginEnabled(
-                        pluginID = it.pluginID,
-                        pluginEnabledStatus = !it.enabled
-                    )
 
-                    if (!it.enabled){
-                        navigateToExecuteScreen(it.pluginID,true)
-                    }else{
-                        coroutineScope.launch {
-                            onAbortOnePlugin(it.pluginID)
+        items(
+            items = renderingList,
+            key = { pluginManifestRoom -> pluginManifestRoom.pluginID }
+        ){ pluginManifestRoom ->
+
+            var actionCanSee by remember { mutableStateOf(false) }
+            var cardSize by remember { mutableStateOf(IntSize.Zero) }
+
+            if (actionCanSee){
+
+                PluginActionContainer(
+                    onShareButtonClick = {},
+                    onDeleteButtonClick = { pluginScreenViewModel.uninstallPlugin(pluginManifestRoom) },
+                    onBackButtonClick = { actionCanSee = !actionCanSee },
+                    modifier = Modifier
+                        .size(
+                            width = with(density) { cardSize.width.toDp() },
+                            height = with(density) { cardSize.height.toDp() }
+                        )
+                )
+
+            }else{
+
+                PluginInfoContainerLocal(
+                    pluginManifest = pluginManifestRoom,
+                    onSwitchClick = {
+                        pluginScreenViewModel.setPluginEnabled(
+                            pluginID = pluginManifestRoom.pluginID,
+                            pluginEnabledStatus = !pluginManifestRoom.enabled
+                        )
+
+                        if (!pluginManifestRoom.enabled){
+                            navigateToExecuteScreen(pluginManifestRoom.pluginID,true)
+                        }else{
+                            coroutineScope.launch {
+                                onAbortOnePlugin(pluginManifestRoom.pluginID)
+                            }
                         }
-                    }
-                },
-                onBadgeClick = {
-                    pluginScreenViewModel.uninstallPlugin(it)
-                },
-                onCardClick = {
-                    if (it.enabled){
-                        navigateToExecuteScreen(it.pluginID,false)
-                    }
-                },
-                badgeShowState = badgeShowState
-            )
+                    },
+                    onCardClick = {
+                        if (pluginManifestRoom.enabled){
+                            navigateToExecuteScreen(pluginManifestRoom.pluginID,false)
+                        }
+                    },
+                    onCardLongClick = { actionCanSee = !actionCanSee },
+                    onCardSizeChanged = { cardSize = it },
+                )
+
+            }
         }
     }
 }

--- a/app/src/main/res/drawable/material_symbols_undo.xml
+++ b/app/src/main/res/drawable/material_symbols_undo.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal"
+    android:autoMirrored="true">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M280,760L280,680L564,680Q627,680 673.5,640Q720,600 720,540Q720,480 673.5,440Q627,400 564,400L312,400L416,504L360,560L160,360L360,160L416,216L312,320L564,320Q661,320 730.5,383Q800,446 800,540Q800,634 730.5,697Q661,760 564,760L280,760Z"/>
+</vector>


### PR DESCRIPTION
Add a long press action state for plugin and environment cards.

Show a fixed size action container with share, back, and delete buttons.

Move uninstall actions from the old badge flow into the long press action state.