### PR TITLE
feat(codebrick)!: Add system tile binding for Code Bricks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,6 +52,74 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <service
+            android:name=".service.tile.CustomTileService_0"
+            android:label="Reverse Tile 0"
+            android:icon="@drawable/ic_launcher_foreground"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="false" />
+        </service>
+        <service
+            android:name=".service.tile.CustomTileService_1"
+            android:label="Reverse Tile 1"
+            android:icon="@drawable/ic_launcher_foreground"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="false" />
+        </service>
+        <service
+            android:name=".service.tile.CustomTileService_2"
+            android:label="Reverse Tile 2"
+            android:icon="@drawable/ic_launcher_foreground"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="false" />
+        </service>
+        <service
+            android:name=".service.tile.CustomTileService_3"
+            android:label="Reverse Tile 3"
+            android:icon="@drawable/ic_launcher_foreground"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="false" />
+        </service>
+        <service
+            android:name=".service.tile.CustomTileService_4"
+            android:label="Reverse Tile 4"
+            android:icon="@drawable/ic_launcher_foreground"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="false" />
+        </service>
+
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/baidaidai/rootless_store/application/codebrick/AddOneCodeBrickUseCase.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/application/codebrick/AddOneCodeBrickUseCase.kt
@@ -12,13 +12,15 @@ class AddOneCodeBrickUseCase @Inject constructor(
         codeBrickTitle: String,
         codeBrickContent: String,
         codeBrickContext: HosterOverallStatus,
+        bindTileIndex: Int?
     ) {
 
         val codeBrickConfig = CodeBrickConfig(
             unixTimeStamp = System.currentTimeMillis(),
             codeBrickTitle = codeBrickTitle,
             codeBrickContent = codeBrickContent,
-            codeBrickEnvironment = codeBrickContext
+            codeBrickEnvironment = codeBrickContext,
+            bindTileIndex = bindTileIndex
         )
 
         codeBrickRepositoryImpl.createOneCodeBrickConfig(codeBrickConfig)

--- a/app/src/main/java/com/baidaidai/rootless_store/application/codebrick/GetCodeBrickConfigByTileIndexUseCase.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/application/codebrick/GetCodeBrickConfigByTileIndexUseCase.kt
@@ -1,0 +1,11 @@
+package com.baidaidai.rootless_store.application.codebrick
+
+import com.baidaidai.rootless_store.data.codebrick.repository.CodeBrickRepositoryImpl
+import com.baidaidai.rootless_store.domain.codebrick.model.CodeBrickConfig
+import javax.inject.Inject
+
+class GetCodeBrickConfigByTileIndexUseCase @Inject constructor(
+    private val codeBrickRepositoryImpl: CodeBrickRepositoryImpl
+) {
+    suspend operator fun invoke(tileIndex: Int): CodeBrickConfig? = codeBrickRepositoryImpl.getCodeBrickConfigByTileIndex(tileIndex)
+}

--- a/app/src/main/java/com/baidaidai/rootless_store/application/codebrick/UpdateOneCodeBrickUseCase.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/application/codebrick/UpdateOneCodeBrickUseCase.kt
@@ -12,6 +12,7 @@ class UpdateOneCodeBrickUseCase @Inject constructor(
         codeBrickTitle: String,
         codeBrickContent: String,
         codeBrickContext: HosterOverallStatus,
+        bindTileIndex: Int?,
         oldCodeBrickConfig: CodeBrickConfig
     ) {
 
@@ -19,7 +20,8 @@ class UpdateOneCodeBrickUseCase @Inject constructor(
             unixTimeStamp = oldCodeBrickConfig.unixTimeStamp,
             codeBrickTitle = codeBrickTitle,
             codeBrickContent = codeBrickContent,
-            codeBrickEnvironment = codeBrickContext
+            codeBrickEnvironment = codeBrickContext,
+            bindTileIndex = bindTileIndex
         )
 
         codeBrickRepositoryImpl.updateOneCodeBrickConfig(codeBrickConfig)

--- a/app/src/main/java/com/baidaidai/rootless_store/data/codebrick/database/CodeBrickDAO.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/data/codebrick/database/CodeBrickDAO.kt
@@ -6,6 +6,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import com.baidaidai.rootless_store.domain.codebrick.model.CodeBrickConfig
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -28,6 +29,9 @@ interface CodeBrickDAO {
 
     @Query("SELECT * FROM CodeBrickEntity")
     fun getAllCodeBrickConfig(): Flow<List<CodeBrickEntity>>
+
+    @Query("SELECT * FROM CodeBrickEntity WHERE bindTileIndex = :tileIndex LIMIT 1")
+    suspend fun getCodeBrickEntityByTileIndex(tileIndex: Int): CodeBrickEntity?
 
     // Delete
     @Delete

--- a/app/src/main/java/com/baidaidai/rootless_store/data/codebrick/database/CodeBrickEntity.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/data/codebrick/database/CodeBrickEntity.kt
@@ -11,5 +11,6 @@ data class CodeBrickEntity(
 
     val codeBrickTitle: String,
     val codeBrickEnvironment: HosterOverallStatus,
-    val codeBrickContent: String
+    val codeBrickContent: String,
+    val bindTileIndex: Int? = null
 )

--- a/app/src/main/java/com/baidaidai/rootless_store/data/codebrick/mapper/CodeBrickMapper.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/data/codebrick/mapper/CodeBrickMapper.kt
@@ -11,7 +11,8 @@ object CodeBrickMapper {
             unixTimeStamp = unixTimeStamp,
             codeBrickTitle = codeBrickTitle,
             codeBrickEnvironment = codeBrickEnvironment,
-            codeBrickContent = codeBrickContent
+            codeBrickContent = codeBrickContent,
+            bindTileIndex = bindTileIndex
         )
     }
 
@@ -21,7 +22,8 @@ object CodeBrickMapper {
             unixTimeStamp = unixTimeStamp,
             codeBrickTitle = codeBrickTitle,
             codeBrickEnvironment = codeBrickEnvironment,
-            codeBrickContent = codeBrickContent
+            codeBrickContent = codeBrickContent,
+            bindTileIndex = bindTileIndex
         )
     }
 

--- a/app/src/main/java/com/baidaidai/rootless_store/data/codebrick/repository/CodeBrickRepositoryImpl.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/data/codebrick/repository/CodeBrickRepositoryImpl.kt
@@ -48,6 +48,11 @@ class CodeBrickRepositoryImpl @Inject constructor(
             }
     }
 
+    suspend fun getCodeBrickConfigByTileIndex(tileIndex: Int): CodeBrickConfig?{
+        val codeBrickConfig = codeBrickDAO.getCodeBrickEntityByTileIndex(tileIndex)?.toCodeBrickConfig()
+        return codeBrickConfig
+    }
+
     // Delete
     suspend fun deleteOneCodeBrickConfig(
         codeBrickConfig: CodeBrickConfig

--- a/app/src/main/java/com/baidaidai/rootless_store/domain/codebrick/model/CodeBrickConfig.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/domain/codebrick/model/CodeBrickConfig.kt
@@ -6,5 +6,6 @@ data class CodeBrickConfig(
     val unixTimeStamp: Long,
     val codeBrickTitle: String,
     val codeBrickEnvironment: HosterOverallStatus,
-    val codeBrickContent: String
+    val codeBrickContent: String,
+    val bindTileIndex: Int? = null
 )

--- a/app/src/main/java/com/baidaidai/rootless_store/domain/codebrick/model/CodeBrickContextConfig.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/domain/codebrick/model/CodeBrickContextConfig.kt
@@ -6,7 +6,8 @@ import com.baidaidai.rootless_store.domain.status.model.HosterOverallStatus
 
 data class CodeBrickContextConfig(
     val contextType: HosterOverallStatus,
-    @StringRes val contextTextResource: Int,
+    @StringRes
+    val contextTextResource: Int,
 
     @DrawableRes
     val contextIcon: Int

--- a/app/src/main/java/com/baidaidai/rootless_store/domain/tile/model/RootlessStoreTileService.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/domain/tile/model/RootlessStoreTileService.kt
@@ -1,0 +1,68 @@
+package com.baidaidai.rootless_store.domain.tile.model
+
+import android.os.Build
+import android.service.quicksettings.TileService
+import androidx.annotation.RequiresApi
+import com.baidaidai.rootless_store.application.codebrick.ExecuteOneCodeBrickUseCase
+import com.baidaidai.rootless_store.application.codebrick.GetCodeBrickConfigByTileIndexUseCase
+import com.baidaidai.rootless_store.domain.codebrick.model.CodeBrickConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+abstract class RootlessStoreTileService: TileService() {
+
+    abstract val tileIndex: Int
+
+    @Inject
+    lateinit var getCodeBrickConfigByTileIndexUseCase: GetCodeBrickConfigByTileIndexUseCase
+
+    @Inject
+    lateinit var executeOneCodeBrickUseCase: ExecuteOneCodeBrickUseCase
+
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var _codeBrickConfig: CodeBrickConfig? = null
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    override fun onStartListening() {
+        super.onStartListening()
+
+        serviceScope.launch {
+            _codeBrickConfig = getCodeBrickConfigByTileIndexUseCase(tileIndex)
+            updateTitleContent()
+        }
+    }
+
+    override fun onClick() {
+        super.onClick()
+
+        serviceScope.launch {
+            val codeBrickConfig = _codeBrickConfig
+            if (codeBrickConfig != null){
+                val resultFlow = executeOneCodeBrickUseCase(codeBrickConfig)
+                resultFlow.collect {
+                    // Do Noting
+                    // TODO("Can Collect, Dispatch to notification")
+                }
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun updateTitleContent(){
+        val codeBrickConfig = _codeBrickConfig
+
+        if (codeBrickConfig != null){
+            qsTile?.apply {
+                label = codeBrickConfig.codeBrickTitle
+                subtitle = codeBrickConfig.codeBrickContent
+                contentDescription = codeBrickConfig.codeBrickTitle
+                updateTile()
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/baidaidai/rootless_store/service/tile/CustomTileService_0.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/service/tile/CustomTileService_0.kt
@@ -1,0 +1,10 @@
+package com.baidaidai.rootless_store.service.tile
+
+import com.baidaidai.rootless_store.domain.tile.model.RootlessStoreTileService
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class CustomTileService_0 @Inject constructor(
+    override val tileIndex: Int = 0
+): RootlessStoreTileService()

--- a/app/src/main/java/com/baidaidai/rootless_store/service/tile/CustomTileService_1.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/service/tile/CustomTileService_1.kt
@@ -1,0 +1,10 @@
+package com.baidaidai.rootless_store.service.tile
+
+import com.baidaidai.rootless_store.domain.tile.model.RootlessStoreTileService
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class CustomTileService_1 @Inject constructor(
+    override val tileIndex: Int = 1
+): RootlessStoreTileService()

--- a/app/src/main/java/com/baidaidai/rootless_store/service/tile/CustomTileService_2.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/service/tile/CustomTileService_2.kt
@@ -1,0 +1,10 @@
+package com.baidaidai.rootless_store.service.tile
+
+import com.baidaidai.rootless_store.domain.tile.model.RootlessStoreTileService
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class CustomTileService_2 @Inject constructor(
+    override val tileIndex: Int = 2
+): RootlessStoreTileService()

--- a/app/src/main/java/com/baidaidai/rootless_store/service/tile/CustomTileService_3.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/service/tile/CustomTileService_3.kt
@@ -1,0 +1,10 @@
+package com.baidaidai.rootless_store.service.tile
+
+import com.baidaidai.rootless_store.domain.tile.model.RootlessStoreTileService
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class CustomTileService_3 @Inject constructor(
+    override val tileIndex: Int = 3
+): RootlessStoreTileService()

--- a/app/src/main/java/com/baidaidai/rootless_store/service/tile/CustomTileService_4.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/service/tile/CustomTileService_4.kt
@@ -1,0 +1,10 @@
+package com.baidaidai.rootless_store.service.tile
+
+import com.baidaidai.rootless_store.domain.tile.model.RootlessStoreTileService
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class CustomTileService_4 @Inject constructor(
+    override val tileIndex: Int = 4
+): RootlessStoreTileService()

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickContextList.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickContextList.kt
@@ -1,0 +1,183 @@
+package com.baidaidai.rootless_store.ui.components.codeBrickScreen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.baidaidai.rootless_store.R
+import com.baidaidai.rootless_store.domain.codebrick.model.CodeBrickContextConfig
+import com.baidaidai.rootless_store.domain.status.model.HosterOverallStatus
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun CodeBrickContextList(
+    modifier: Modifier = Modifier,
+    currentSelectedContext: CodeBrickContextConfig,
+    brickContextConfigList: List<CodeBrickContextConfig>,
+    onListItemClick: (codeBrickContextConfig: CodeBrickContextConfig)-> Unit
+){
+
+    val focusedListItemStyle = ListItemColors(
+        containerColor = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        leadingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        trailingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        overlineContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        supportingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        disabledContainerColor = MaterialTheme.colorScheme.primaryContainer,
+        disabledContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        disabledLeadingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        disabledTrailingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        disabledOverlineContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        disabledSupportingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+        selectedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        selectedLeadingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        selectedTrailingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        selectedOverlineContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        selectedSupportingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        draggedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+        draggedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        draggedLeadingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        draggedTrailingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        draggedOverlineContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        draggedSupportingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+    )
+    val unfocusedListItemStyle = ListItemColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        leadingContentColor = MaterialTheme.colorScheme.onSurface,
+        trailingContentColor = MaterialTheme.colorScheme.onSurface,
+        overlineContentColor = MaterialTheme.colorScheme.onSurface,
+        supportingContentColor = MaterialTheme.colorScheme.onSurface,
+        disabledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+        disabledContentColor = MaterialTheme.colorScheme.onSurface,
+        disabledLeadingContentColor = MaterialTheme.colorScheme.onSurface,
+        disabledTrailingContentColor = MaterialTheme.colorScheme.onSurface,
+        disabledOverlineContentColor = MaterialTheme.colorScheme.onSurface,
+        disabledSupportingContentColor = MaterialTheme.colorScheme.onSurface,
+        selectedContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+        selectedContentColor = MaterialTheme.colorScheme.onSurface,
+        selectedLeadingContentColor = MaterialTheme.colorScheme.onSurface,
+        selectedTrailingContentColor = MaterialTheme.colorScheme.onSurface,
+        selectedOverlineContentColor = MaterialTheme.colorScheme.onSurface,
+        selectedSupportingContentColor = MaterialTheme.colorScheme.onSurface,
+        draggedContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+        draggedContentColor = MaterialTheme.colorScheme.onSurface,
+        draggedLeadingContentColor = MaterialTheme.colorScheme.onSurface,
+        draggedTrailingContentColor = MaterialTheme.colorScheme.onSurface,
+        draggedOverlineContentColor = MaterialTheme.colorScheme.onSurface,
+        draggedSupportingContentColor = MaterialTheme.colorScheme.onSurface,
+    )
+
+    var contextListContentCanSee by remember { mutableStateOf(false) }
+
+    fun contextListItemColors(index: Int): ListItemColors{
+        return if (brickContextConfigList[index].contextType == currentSelectedContext.contextType){
+            focusedListItemStyle
+        }else{
+            unfocusedListItemStyle
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(16.dp))
+    ) {
+        ListItem(
+            onClick = { contextListContentCanSee = !contextListContentCanSee },
+            trailingContent = {
+                Icon(
+                    painter = painterResource(R.drawable.material_symbols_keyboard_arrow_down_icon),
+                    contentDescription = "Expand More"
+                )
+            },
+            colors = unfocusedListItemStyle
+        ){
+            Text(
+                text = stringResource(R.string.code_brick_screen_editor_brick_context_title),
+                style = MaterialTheme.typography.titleMedium
+            )
+        }
+        if (contextListContentCanSee){
+            Spacer(modifier = Modifier.height(2.dp))
+            brickContextConfigList.forEachIndexed { index, codeBrickContextConfig ->
+                val contextText = stringResource(codeBrickContextConfig.contextTextResource)
+
+                ListItem(
+                    onClick = { onListItemClick(codeBrickContextConfig) },
+                    leadingContent = {
+                        Icon(
+                            painter = painterResource(codeBrickContextConfig .contextIcon),
+                            contentDescription = contextText
+                        )
+                    },
+                    colors = contextListItemColors(index),
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(4.dp))
+                ) {
+                    Text(contextText)
+                }
+
+                if (index != 2){
+                    Spacer(Modifier.height(2.dp))
+                }
+            }
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun _CodeBrickContextListPreview_() {
+
+    val brickContextConfigList = listOf(
+        CodeBrickContextConfig(
+            contextType = HosterOverallStatus.LIMITED,
+            contextTextResource = R.string.code_brick_screen_editor_context_app_shell_label,
+            contextIcon = R.drawable.material_symbols_applicaitons
+        ),
+        CodeBrickContextConfig(
+            contextType = HosterOverallStatus.ADB,
+            contextTextResource = R.string.code_brick_screen_editor_context_adb_shell_label,
+            contextIcon = R.drawable.material_symbols_adb
+        ),
+        CodeBrickContextConfig(
+            contextType = HosterOverallStatus.ROOTD,
+            contextTextResource = R.string.code_brick_screen_editor_context_root_shell_label,
+            contextIcon = R.drawable.material_symbols_cyclone
+        )
+    )
+
+    var currentSelectedContext by remember { mutableStateOf(brickContextConfigList[0]) }
+
+    CodeBrickContextList(
+        currentSelectedContext = currentSelectedContext,
+        brickContextConfigList = brickContextConfigList,
+        modifier = Modifier
+            .width(300.dp)
+            .background(color = MaterialTheme.colorScheme.surface)
+            .padding(16.dp)
+    ) { }
+}

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickEditor.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickEditor.kt
@@ -1,21 +1,9 @@
 package com.baidaidai.rootless_store.ui.components.codeBrickScreen
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemColors
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -23,176 +11,21 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.compose.ui.unit.dp
 import com.baidaidai.rootless_store.R
-import com.baidaidai.rootless_store.domain.codebrick.model.CodeBrickContextConfig
 import com.baidaidai.rootless_store.domain.status.model.HosterOverallStatus
-
-
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Composable
-private fun CodeBrickEditorContent(
-    modifier: Modifier = Modifier,
-    titleContent: String,
-    codeContent: String,
-    onCodeBrickTitleValueChange: (value: String)-> Unit,
-    onCodeBrickContentValueChange: (value: String)-> Unit,
-    onCodeBrickContextValueChange: (hosterOverallStatus: HosterOverallStatus) -> Unit
-){
-
-    val focusedListItemStyle = ListItemColors(
-        containerColor = MaterialTheme.colorScheme.primaryContainer,
-        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        leadingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        trailingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        overlineContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        supportingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        disabledContainerColor = MaterialTheme.colorScheme.primaryContainer,
-        disabledContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        disabledLeadingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        disabledTrailingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        disabledOverlineContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        disabledSupportingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-        selectedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        selectedLeadingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        selectedTrailingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        selectedOverlineContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        selectedSupportingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        draggedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-        draggedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        draggedLeadingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        draggedTrailingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        draggedOverlineContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        draggedSupportingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-    )
-    val unfocusedListItemStyle = ListItemColors(
-        containerColor = MaterialTheme.colorScheme.surface,
-        contentColor = MaterialTheme.colorScheme.onSurface,
-        leadingContentColor = MaterialTheme.colorScheme.onSurface,
-        trailingContentColor = MaterialTheme.colorScheme.onSurface,
-        overlineContentColor = MaterialTheme.colorScheme.onSurface,
-        supportingContentColor = MaterialTheme.colorScheme.onSurface,
-        disabledContainerColor = MaterialTheme.colorScheme.surface,
-        disabledContentColor = MaterialTheme.colorScheme.onSurface,
-        disabledLeadingContentColor = MaterialTheme.colorScheme.onSurface,
-        disabledTrailingContentColor = MaterialTheme.colorScheme.onSurface,
-        disabledOverlineContentColor = MaterialTheme.colorScheme.onSurface,
-        disabledSupportingContentColor = MaterialTheme.colorScheme.onSurface,
-        selectedContainerColor = MaterialTheme.colorScheme.surface,
-        selectedContentColor = MaterialTheme.colorScheme.onSurface,
-        selectedLeadingContentColor = MaterialTheme.colorScheme.onSurface,
-        selectedTrailingContentColor = MaterialTheme.colorScheme.onSurface,
-        selectedOverlineContentColor = MaterialTheme.colorScheme.onSurface,
-        selectedSupportingContentColor = MaterialTheme.colorScheme.onSurface,
-        draggedContainerColor = MaterialTheme.colorScheme.surface,
-        draggedContentColor = MaterialTheme.colorScheme.onSurface,
-        draggedLeadingContentColor = MaterialTheme.colorScheme.onSurface,
-        draggedTrailingContentColor = MaterialTheme.colorScheme.onSurface,
-        draggedOverlineContentColor = MaterialTheme.colorScheme.onSurface,
-        draggedSupportingContentColor = MaterialTheme.colorScheme.onSurface,
-    )
-
-    val brickContextConfigList = listOf(
-        CodeBrickContextConfig(
-            contextType = HosterOverallStatus.LIMITED,
-            contextTextResource = R.string.code_brick_screen_editor_context_app_shell_label,
-            contextIcon = R.drawable.material_symbols_applicaitons
-        ),
-        CodeBrickContextConfig(
-            contextType = HosterOverallStatus.ADB,
-            contextTextResource = R.string.code_brick_screen_editor_context_adb_shell_label,
-            contextIcon = R.drawable.material_symbols_adb
-        ),
-        CodeBrickContextConfig(
-            contextType = HosterOverallStatus.ROOTD,
-            contextTextResource = R.string.code_brick_screen_editor_context_root_shell_label,
-            contextIcon = R.drawable.material_symbols_cyclone
-        )
-    )
-    var currentSelectedContext by remember { mutableStateOf(brickContextConfigList[0]) }
-
-    fun listItemColors(index: Int): ListItemColors{
-        return if (brickContextConfigList[index].contextType == currentSelectedContext.contextType){
-            focusedListItemStyle
-        }else{
-            unfocusedListItemStyle
-        }
-    }
-
-    Column(modifier) {
-
-        OutlinedTextField(
-            value = titleContent,
-            onValueChange = onCodeBrickTitleValueChange,
-            label = {
-                Text(stringResource(R.string.code_brick_screen_editor_brick_name_label))
-            }
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        OutlinedTextField(
-            value = codeContent,
-            onValueChange = onCodeBrickContentValueChange,
-            label = {
-                Text(stringResource(R.string.code_brick_screen_editor_shell_script_label))
-            }
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        Text(
-            text = stringResource(R.string.code_brick_screen_editor_brick_context_title),
-            style = MaterialTheme.typography.titleMedium
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        brickContextConfigList.forEachIndexed { index, codeBrickContextConfig ->
-            val contextText = stringResource(codeBrickContextConfig.contextTextResource)
-
-            ListItem(
-                onClick = {
-                    currentSelectedContext = codeBrickContextConfig
-                    onCodeBrickContextValueChange(codeBrickContextConfig.contextType)
-                },
-                leadingContent = {
-                    Icon(
-                        painter = painterResource(codeBrickContextConfig .contextIcon),
-                        contentDescription = contextText
-                    )
-                },
-                colors = listItemColors(index),
-                modifier = Modifier
-                    .clip(RoundedCornerShape(16.dp))
-            ) {
-                Text(contextText)
-            }
-
-            if (index != 2){
-                Spacer(Modifier.height(2.dp))
-            }
-        }
-
-    }
-}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CodeBrickEditor(
     onDismissRequest: () -> Unit,
     onDismissButtonClick: ()-> Unit,
-    onConfirmButtonClick: (title: String,content: String,context: HosterOverallStatus)-> Unit
+    onConfirmButtonClick: (title: String,content: String,context: HosterOverallStatus,tileIndex: Int?)-> Unit
 ){
 
     var titleContent by remember { mutableStateOf("") }
     var codeContent by remember { mutableStateOf("") }
+    var tileIndex: Int? by remember { mutableStateOf(null) }
     var selectedContext by remember { mutableStateOf(HosterOverallStatus.LIMITED) }
 
     AlertDialog(
@@ -209,7 +42,7 @@ fun CodeBrickEditor(
         },
         confirmButton = {
             Button(
-                onClick = { onConfirmButtonClick(titleContent,codeContent, selectedContext) }
+                onClick = { onConfirmButtonClick(titleContent,codeContent, selectedContext, tileIndex) }
             ) {
                 Text(stringResource(R.string.code_brick_screen_editor_confirm_button))
             }
@@ -218,28 +51,13 @@ fun CodeBrickEditor(
             CodeBrickEditorContent(
                 titleContent = titleContent,
                 codeContent = codeContent,
+                tileIndex = tileIndex,
                 onCodeBrickTitleValueChange = { titleContent = it },
                 onCodeBrickContentValueChange = { codeContent = it },
-                onCodeBrickContextValueChange = { selectedContext = it }
+                onCodeBrickContextValueChange = { selectedContext = it },
+                onCodeBrickTileValueChange = { tileIndex = it }
             )
         },
         containerColor = MaterialTheme.colorScheme.surface
-    )
-}
-
-@PreviewLightDark
-@Composable
-private fun _preview_(){
-    CodeBrickEditorContent(
-        modifier = Modifier
-            .background(MaterialTheme.colorScheme.surface)
-            .width(280.dp)
-            .heightIn(min = 300.dp)
-        ,
-        titleContent = "a",
-        codeContent =  "b",
-        onCodeBrickTitleValueChange =  {},
-        onCodeBrickContentValueChange = {},
-        onCodeBrickContextValueChange = {}
     )
 }

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickEditorContent.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickEditorContent.kt
@@ -1,0 +1,121 @@
+package com.baidaidai.rootless_store.ui.components.codeBrickScreen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.baidaidai.rootless_store.R
+import com.baidaidai.rootless_store.domain.codebrick.model.CodeBrickContextConfig
+import com.baidaidai.rootless_store.domain.status.model.HosterOverallStatus
+
+@Composable
+fun CodeBrickEditorContent(
+
+    modifier: Modifier = Modifier,
+    titleContent: String,
+    tileIndex: Int?,
+    codeContent: String,
+    onCodeBrickTitleValueChange: (value: String)-> Unit,
+    onCodeBrickTileValueChange: (value: Int?) -> Unit,
+    onCodeBrickContentValueChange: (value: String)-> Unit,
+    onCodeBrickContextValueChange: (hosterOverallStatus: HosterOverallStatus) -> Unit
+
+){
+
+    val brickContextConfigList = listOf(
+        CodeBrickContextConfig(
+            contextType = HosterOverallStatus.LIMITED,
+            contextTextResource = R.string.code_brick_screen_editor_context_app_shell_label,
+            contextIcon = R.drawable.material_symbols_applicaitons
+        ),
+        CodeBrickContextConfig(
+            contextType = HosterOverallStatus.ADB,
+            contextTextResource = R.string.code_brick_screen_editor_context_adb_shell_label,
+            contextIcon = R.drawable.material_symbols_adb
+        ),
+        CodeBrickContextConfig(
+            contextType = HosterOverallStatus.ROOTD,
+            contextTextResource = R.string.code_brick_screen_editor_context_root_shell_label,
+            contextIcon = R.drawable.material_symbols_cyclone
+        )
+    )
+
+    var currentSelectedContext by remember { mutableStateOf(brickContextConfigList[0]) }
+
+    Column(modifier) {
+
+        OutlinedTextField(
+            value = titleContent,
+            onValueChange = onCodeBrickTitleValueChange,
+            label = {
+                Text(stringResource(R.string.code_brick_screen_editor_brick_name_label))
+            }
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        OutlinedTextField(
+            value = codeContent,
+            onValueChange = onCodeBrickContentValueChange,
+            label = {
+                Text(stringResource(R.string.code_brick_screen_editor_shell_script_label))
+            }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        CodeBrickContextList(
+            currentSelectedContext = currentSelectedContext,
+            brickContextConfigList = brickContextConfigList,
+            onListItemClick = { codeBrickContextConfig ->
+                currentSelectedContext = codeBrickContextConfig
+                onCodeBrickContextValueChange(codeBrickContextConfig.contextType)
+            }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        CodeBrickTileList(
+            tileBinderIndex = tileIndex
+        ) { newTileBinderIndex ->
+            onCodeBrickTileValueChange(newTileBinderIndex)
+        }
+
+    }
+
+}
+
+@PreviewLightDark
+@Composable
+private fun _preview_(){
+    CodeBrickEditorContent(
+        modifier = Modifier
+            .background(MaterialTheme.colorScheme.surface)
+            .width(280.dp)
+            .heightIn(min = 300.dp)
+            .padding(16.dp)
+        ,
+        titleContent = "a",
+        tileIndex = null,
+        codeContent =  "b",
+        onCodeBrickTitleValueChange =  {},
+        onCodeBrickContentValueChange = {},
+        onCodeBrickContextValueChange = {},
+        onCodeBrickTileValueChange = {}
+    )
+}

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickSetting.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickSetting.kt
@@ -1,21 +1,9 @@
 package com.baidaidai.rootless_store.ui.components.codeBrickScreen
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemColors
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -24,167 +12,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.compose.ui.unit.dp
 import com.baidaidai.rootless_store.R
 import com.baidaidai.rootless_store.domain.codebrick.model.CodeBrickConfig
-import com.baidaidai.rootless_store.domain.codebrick.model.CodeBrickContextConfig
 import com.baidaidai.rootless_store.domain.status.model.HosterOverallStatus
-
-
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
-@Composable
-private fun CodeBrickSettingContent(
-    modifier: Modifier = Modifier,
-    titleContent: String,
-    codeContent: String,
-    brickContext: HosterOverallStatus,
-    onCodeBrickTitleValueChange: (value: String)-> Unit,
-    onCodeBrickContentValueChange: (value: String)-> Unit,
-    onCodeBrickContextValueChange: (hosterOverallStatus: HosterOverallStatus) -> Unit
-){
-
-    val focusedListItemStyle = ListItemColors(
-        containerColor = MaterialTheme.colorScheme.primaryContainer,
-        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        leadingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        trailingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        overlineContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        supportingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        disabledContainerColor = MaterialTheme.colorScheme.primaryContainer,
-        disabledContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        disabledLeadingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        disabledTrailingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        disabledOverlineContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        disabledSupportingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-        selectedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        selectedLeadingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        selectedTrailingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        selectedOverlineContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        selectedSupportingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        draggedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-        draggedContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        draggedLeadingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        draggedTrailingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        draggedOverlineContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        draggedSupportingContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-    )
-    val unfocusedListItemStyle = ListItemColors(
-        containerColor = MaterialTheme.colorScheme.surface,
-        contentColor = MaterialTheme.colorScheme.onSurface,
-        leadingContentColor = MaterialTheme.colorScheme.onSurface,
-        trailingContentColor = MaterialTheme.colorScheme.onSurface,
-        overlineContentColor = MaterialTheme.colorScheme.onSurface,
-        supportingContentColor = MaterialTheme.colorScheme.onSurface,
-        disabledContainerColor = MaterialTheme.colorScheme.surface,
-        disabledContentColor = MaterialTheme.colorScheme.onSurface,
-        disabledLeadingContentColor = MaterialTheme.colorScheme.onSurface,
-        disabledTrailingContentColor = MaterialTheme.colorScheme.onSurface,
-        disabledOverlineContentColor = MaterialTheme.colorScheme.onSurface,
-        disabledSupportingContentColor = MaterialTheme.colorScheme.onSurface,
-        selectedContainerColor = MaterialTheme.colorScheme.surface,
-        selectedContentColor = MaterialTheme.colorScheme.onSurface,
-        selectedLeadingContentColor = MaterialTheme.colorScheme.onSurface,
-        selectedTrailingContentColor = MaterialTheme.colorScheme.onSurface,
-        selectedOverlineContentColor = MaterialTheme.colorScheme.onSurface,
-        selectedSupportingContentColor = MaterialTheme.colorScheme.onSurface,
-        draggedContainerColor = MaterialTheme.colorScheme.surface,
-        draggedContentColor = MaterialTheme.colorScheme.onSurface,
-        draggedLeadingContentColor = MaterialTheme.colorScheme.onSurface,
-        draggedTrailingContentColor = MaterialTheme.colorScheme.onSurface,
-        draggedOverlineContentColor = MaterialTheme.colorScheme.onSurface,
-        draggedSupportingContentColor = MaterialTheme.colorScheme.onSurface,
-    )
-
-    val brickContextConfigList = listOf(
-        CodeBrickContextConfig(
-            contextType = HosterOverallStatus.LIMITED,
-            contextTextResource = R.string.code_brick_screen_editor_context_app_shell_label,
-            contextIcon = R.drawable.material_symbols_applicaitons
-        ),
-        CodeBrickContextConfig(
-            contextType = HosterOverallStatus.ADB,
-            contextTextResource = R.string.code_brick_screen_editor_context_adb_shell_label,
-            contextIcon = R.drawable.material_symbols_adb
-        ),
-        CodeBrickContextConfig(
-            contextType = HosterOverallStatus.ROOTD,
-            contextTextResource = R.string.code_brick_screen_editor_context_root_shell_label,
-            contextIcon = R.drawable.material_symbols_cyclone
-        )
-    )
-
-
-
-    fun listItemColors(index: Int): ListItemColors{
-        return if (brickContextConfigList[index].contextType == brickContext){
-            focusedListItemStyle
-        }else{
-            unfocusedListItemStyle
-        }
-    }
-
-    Column(modifier) {
-
-        OutlinedTextField(
-            value = titleContent,
-            onValueChange = onCodeBrickTitleValueChange,
-            label = {
-                Text(stringResource(R.string.code_brick_screen_editor_brick_name_label))
-            }
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        OutlinedTextField(
-            value = codeContent,
-            onValueChange = onCodeBrickContentValueChange,
-            label = {
-                Text(stringResource(R.string.code_brick_screen_editor_shell_script_label))
-            }
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        Text(
-            text = stringResource(R.string.code_brick_screen_editor_brick_context_title),
-            style = MaterialTheme.typography.titleMedium
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
-        brickContextConfigList.forEachIndexed { index, codeBrickContextConfig ->
-            val contextText = stringResource(codeBrickContextConfig.contextTextResource)
-
-            ListItem(
-                onClick = {
-                    onCodeBrickContextValueChange(codeBrickContextConfig.contextType)
-                },
-                leadingContent = {
-                    Icon(
-                        painter = painterResource(codeBrickContextConfig .contextIcon),
-                        contentDescription = contextText
-                    )
-                },
-                colors = listItemColors(index),
-                modifier = Modifier
-                    .clip(RoundedCornerShape(16.dp))
-            ) {
-                Text(contextText)
-            }
-
-            if (index != 2){
-                Spacer(Modifier.height(2.dp))
-            }
-        }
-
-    }
-}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -192,16 +23,24 @@ fun CodeBrickSetting(
     codeBrickConfig: CodeBrickConfig,
     onDismissRequest: () -> Unit,
     onDismissButtonClick: ()-> Unit,
-    onConfirmButtonClick: (title: String,content: String,context: HosterOverallStatus,oldCodeBrickConfig: CodeBrickConfig)-> Unit
+    onConfirmButtonClick: (
+        title: String,
+        content: String,
+        context: HosterOverallStatus,
+        tileIndex: Int?,
+        oldCodeBrickConfig: CodeBrickConfig
+    )-> Unit
 ){
 
     var titleContent by remember { mutableStateOf("") }
     var codeContent by remember { mutableStateOf("") }
+    var tileIndex: Int? by remember { mutableStateOf(null) }
     var selectedContext by remember { mutableStateOf(HosterOverallStatus.LIMITED) }
 
     LaunchedEffect(codeBrickConfig) {
         titleContent = codeBrickConfig.codeBrickTitle
         codeContent = codeBrickConfig.codeBrickContent
+        tileIndex = codeBrickConfig.bindTileIndex
         selectedContext = codeBrickConfig.codeBrickEnvironment
     }
 
@@ -220,7 +59,13 @@ fun CodeBrickSetting(
         confirmButton = {
             Button(
                 onClick = {
-                    onConfirmButtonClick(titleContent, codeContent, selectedContext, codeBrickConfig)
+                    onConfirmButtonClick(
+                        titleContent,
+                        codeContent,
+                        selectedContext,
+                        tileIndex,
+                        codeBrickConfig
+                    )
                 }
             ) {
                 Text(stringResource(R.string.code_brick_screen_editor_confirm_button))
@@ -230,30 +75,14 @@ fun CodeBrickSetting(
             CodeBrickSettingContent(
                 titleContent = titleContent,
                 codeContent = codeContent,
+                tileIndex = tileIndex,
                 brickContext = selectedContext,
                 onCodeBrickTitleValueChange = { titleContent = it },
                 onCodeBrickContentValueChange = { codeContent = it },
-                onCodeBrickContextValueChange = { selectedContext = it }
+                onCodeBrickContextValueChange = { selectedContext = it },
+                onCodeBrickTileValueChange = { tileIndex = it }
             )
         },
         containerColor = MaterialTheme.colorScheme.surface
-    )
-}
-
-@PreviewLightDark
-@Composable
-private fun _preview_(){
-    CodeBrickSettingContent(
-        modifier = Modifier
-            .background(MaterialTheme.colorScheme.surface)
-            .width(280.dp)
-            .heightIn(min = 300.dp)
-        ,
-        titleContent = "a",
-        codeContent =  "b",
-        brickContext = HosterOverallStatus.ADB,
-        onCodeBrickTitleValueChange =  {},
-        onCodeBrickContentValueChange = {},
-        onCodeBrickContextValueChange = {}
     )
 }

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickSettingContent.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickSettingContent.kt
@@ -1,0 +1,116 @@
+package com.baidaidai.rootless_store.ui.components.codeBrickScreen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.baidaidai.rootless_store.R
+import com.baidaidai.rootless_store.domain.codebrick.model.CodeBrickContextConfig
+import com.baidaidai.rootless_store.domain.status.model.HosterOverallStatus
+
+@Composable
+fun CodeBrickSettingContent(
+    modifier: Modifier = Modifier,
+    titleContent: String,
+    codeContent: String,
+    tileIndex: Int?,
+    brickContext: HosterOverallStatus,
+    onCodeBrickTitleValueChange: (value: String)-> Unit,
+    onCodeBrickContentValueChange: (value: String)-> Unit,
+    onCodeBrickContextValueChange: (hosterOverallStatus: HosterOverallStatus) -> Unit,
+    onCodeBrickTileValueChange: (value: Int?) -> Unit,
+){
+
+    val brickContextConfigList = listOf(
+        CodeBrickContextConfig(
+            contextType = HosterOverallStatus.LIMITED,
+            contextTextResource = R.string.code_brick_screen_editor_context_app_shell_label,
+            contextIcon = R.drawable.material_symbols_applicaitons
+        ),
+        CodeBrickContextConfig(
+            contextType = HosterOverallStatus.ADB,
+            contextTextResource = R.string.code_brick_screen_editor_context_adb_shell_label,
+            contextIcon = R.drawable.material_symbols_adb
+        ),
+        CodeBrickContextConfig(
+            contextType = HosterOverallStatus.ROOTD,
+            contextTextResource = R.string.code_brick_screen_editor_context_root_shell_label,
+            contextIcon = R.drawable.material_symbols_cyclone
+        )
+    )
+
+    val currentSelectedContext = brickContextConfigList.firstOrNull { codeBrickContextConfig ->
+        codeBrickContextConfig.contextType == brickContext
+    } ?: brickContextConfigList.first()
+
+    Column(modifier) {
+
+        OutlinedTextField(
+            value = titleContent,
+            onValueChange = onCodeBrickTitleValueChange,
+            label = {
+                Text(stringResource(R.string.code_brick_screen_editor_brick_name_label))
+            }
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        OutlinedTextField(
+            value = codeContent,
+            onValueChange = onCodeBrickContentValueChange,
+            label = {
+                Text(stringResource(R.string.code_brick_screen_editor_shell_script_label))
+            }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        CodeBrickContextList(
+            currentSelectedContext = currentSelectedContext,
+            brickContextConfigList = brickContextConfigList,
+            onListItemClick = { codeBrickContextConfig ->
+                onCodeBrickContextValueChange(codeBrickContextConfig.contextType)
+            }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        CodeBrickTileList(
+            tileBinderIndex = tileIndex
+        ) { newTileBinderIndex ->
+            onCodeBrickTileValueChange(newTileBinderIndex)
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun _CodeBrickSettingContentPreview_(){
+    CodeBrickSettingContent(
+        modifier = Modifier
+            .background(MaterialTheme.colorScheme.surface)
+            .width(280.dp)
+            .heightIn(min = 300.dp)
+            .padding(16.dp)
+        ,
+        titleContent = "Brick",
+        codeContent =  "echo hello",
+        tileIndex = 1,
+        brickContext = HosterOverallStatus.ADB,
+        onCodeBrickTitleValueChange =  {},
+        onCodeBrickContentValueChange = {},
+        onCodeBrickContextValueChange = {},
+        onCodeBrickTileValueChange = {}
+    )
+}

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickTileList.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickTileList.kt
@@ -1,0 +1,142 @@
+package com.baidaidai.rootless_store.ui.components.codeBrickScreen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.baidaidai.rootless_store.R
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun CodeBrickTileList(
+    modifier: Modifier = Modifier,
+    tileBinderIndex: Int?,
+    onValueChange:(newTileBinderIndex: Int?)-> Unit
+){
+
+    val unfocusedListItemStyle = ListItemColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        leadingContentColor = MaterialTheme.colorScheme.onSurface,
+        trailingContentColor = MaterialTheme.colorScheme.onSurface,
+        overlineContentColor = MaterialTheme.colorScheme.onSurface,
+        supportingContentColor = MaterialTheme.colorScheme.onSurface,
+        disabledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+        disabledContentColor = MaterialTheme.colorScheme.onSurface,
+        disabledLeadingContentColor = MaterialTheme.colorScheme.onSurface,
+        disabledTrailingContentColor = MaterialTheme.colorScheme.onSurface,
+        disabledOverlineContentColor = MaterialTheme.colorScheme.onSurface,
+        disabledSupportingContentColor = MaterialTheme.colorScheme.onSurface,
+        selectedContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+        selectedContentColor = MaterialTheme.colorScheme.onSurface,
+        selectedLeadingContentColor = MaterialTheme.colorScheme.onSurface,
+        selectedTrailingContentColor = MaterialTheme.colorScheme.onSurface,
+        selectedOverlineContentColor = MaterialTheme.colorScheme.onSurface,
+        selectedSupportingContentColor = MaterialTheme.colorScheme.onSurface,
+        draggedContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+        draggedContentColor = MaterialTheme.colorScheme.onSurface,
+        draggedLeadingContentColor = MaterialTheme.colorScheme.onSurface,
+        draggedTrailingContentColor = MaterialTheme.colorScheme.onSurface,
+        draggedOverlineContentColor = MaterialTheme.colorScheme.onSurface,
+        draggedSupportingContentColor = MaterialTheme.colorScheme.onSurface,
+    )
+
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(16.dp))
+    ) {
+
+        var tileListContentCanSee by remember { mutableStateOf(false) }
+
+        ListItem(
+            onClick = { tileListContentCanSee = !tileListContentCanSee },
+            trailingContent = {
+                Icon(
+                    painter = painterResource(R.drawable.material_symbols_keyboard_arrow_down_icon),
+                    contentDescription = "Expand More"
+                )
+            },
+            colors = unfocusedListItemStyle
+        ) {
+
+            Text(
+                text = "Tile Binder (New)",
+                style = MaterialTheme.typography.titleMedium
+            )
+
+        }
+        if (tileListContentCanSee) {
+
+            Spacer(modifier = Modifier.height(2.dp))
+
+            val tileBinderText = tileBinderIndex?.toString().orEmpty()
+
+            BasicTextField(
+                value = tileBinderText,
+                singleLine = true,
+                onValueChange = { newValue ->
+                    if (newValue.isEmpty()) {
+                        onValueChange(null)
+                        return@BasicTextField
+                    }
+
+                    val number = newValue.toIntOrNull()
+                    if (number != null && number in 0..4) {
+                        onValueChange(number)
+                    }
+                },
+                decorationBox = { innerTextField ->
+                    Box(
+                        contentAlignment = Alignment.CenterStart,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(16.dp)
+                    ) {
+                        if (tileBinderText.isEmpty()) {
+                            Text(
+                                text = "Input tile binder： 0-4",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        innerTextField()
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .background(color = MaterialTheme.colorScheme.surfaceContainer)
+            )
+
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun _CodeBrickTileListPreview_() {
+    CodeBrickTileList(tileBinderIndex = null, onValueChange = {})
+}

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/model/RootlessStoreCodeBrickViewModel.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/model/RootlessStoreCodeBrickViewModel.kt
@@ -96,10 +96,11 @@ class RootlessStoreCodeBrickViewModel @Inject constructor(
     fun createOneCodeBrick(
         codeBrickTitle: String,
         codeBrickContent: String,
-        codeBrickContext: HosterOverallStatus
+        codeBrickContext: HosterOverallStatus,
+        bindTileIndex: Int?
     ){
         viewModelScope.launch {
-            addOneCodeBrickUseCase(codeBrickTitle,codeBrickContent,codeBrickContext)
+            addOneCodeBrickUseCase(codeBrickTitle,codeBrickContent,codeBrickContext,bindTileIndex)
         }
     }
 
@@ -108,6 +109,7 @@ class RootlessStoreCodeBrickViewModel @Inject constructor(
         codeBrickTitle: String,
         codeBrickContent: String,
         codeBrickContext: HosterOverallStatus,
+        bindTileIndex: Int?,
         oldCodeBrickConfig: CodeBrickConfig
     ){
         viewModelScope.launch {
@@ -115,6 +117,7 @@ class RootlessStoreCodeBrickViewModel @Inject constructor(
                 codeBrickTitle = codeBrickTitle,
                 codeBrickContent = codeBrickContent,
                 codeBrickContext = codeBrickContext,
+                bindTileIndex = bindTileIndex,
                 oldCodeBrickConfig = oldCodeBrickConfig
             )
         }

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/screens/CodeBrickScreen.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/screens/CodeBrickScreen.kt
@@ -36,11 +36,12 @@ fun CodeBrickScreen(
             onDismissButtonClick = {
                 codeBrickViewModel.changeEditorShowStatus(false)
             },
-            onConfirmButtonClick = { title, content, context ->
+            onConfirmButtonClick = { title, content, context, tileIndex ->
                 codeBrickViewModel.createOneCodeBrick(
                     codeBrickTitle = title,
                     codeBrickContent = content,
-                    codeBrickContext = context
+                    codeBrickContext = context,
+                    bindTileIndex = tileIndex
                 )
                 codeBrickViewModel.changeEditorShowStatus(false)
             },
@@ -61,11 +62,12 @@ fun CodeBrickScreen(
             onDismissButtonClick = {
                 codeBrickViewModel.closeSettingShowStatus(false)
             },
-            onConfirmButtonClick = { title, content, context, oldCodeBrickConfig ->
+            onConfirmButtonClick = { title, content, context, tileIndex, oldCodeBrickConfig ->
                 codeBrickViewModel.updateOneCodeBrick(
                     codeBrickTitle = title,
                     codeBrickContent = content,
                     codeBrickContext = context,
+                    bindTileIndex = tileIndex,
                     oldCodeBrickConfig = oldCodeBrickConfig
                 )
                 codeBrickViewModel.closeSettingShowStatus(false)


### PR DESCRIPTION
Add tile index binding to Code Brick configs and storage.

Register five Quick Settings tile services for bound Code Bricks.

Execute the bound Code Brick when a system tile is clicked.

Wire tile binding into Code Brick create and edit flows.