### PR TITLE
feat(plugin)!: Expand plugin manifest runtime fields

### DIFF
--- a/app/src/main/java/com/baidaidai/rootless_store/application/codebrick/ConvertOneCodeBrickToPluginUseCase.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/application/codebrick/ConvertOneCodeBrickToPluginUseCase.kt
@@ -5,7 +5,7 @@ import com.baidaidai.rootless_store.data.plugin.gateway.PluginGatewayImpl
 import com.baidaidai.rootless_store.data.plugin.repository.PluginRepositoryImpl
 import com.baidaidai.rootless_store.domain.codebrick.model.CodeBrickConfig
 import com.baidaidai.rootless_store.domain.plugin.manifest.PluginManifestLocal
-import kotlinx.serialization.encodeToString
+import com.baidaidai.rootless_store.domain.plugin.model.PluginRunModel
 import kotlinx.serialization.json.Json
 import java.io.File
 import javax.inject.Inject
@@ -35,7 +35,8 @@ class ConvertOneCodeBrickToPluginUseCase @Inject constructor(
             author = "CodeBrick",
             pluginDescription = "Generated from CodeBrick",
             requiredEnvironment = codeBrickConfig.codeBrickEnvironment,
-            entryPoint = "index.sh"
+            entryPoint = "index.sh",
+            pluginRunModel = PluginRunModel.OneTime
         )
         val pluginManifestJson = json.encodeToString(pluginManifestLocal)
 

--- a/app/src/main/java/com/baidaidai/rootless_store/data/plugin/database/PluginInfoEntity.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/data/plugin/database/PluginInfoEntity.kt
@@ -3,7 +3,7 @@ package com.baidaidai.rootless_store.data.plugin.database
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.baidaidai.rootless_store.domain.status.model.HosterOverallStatus
-import com.baidaidai.rootless_store.domain.plugin.manifest.PluginManifestRoom
+import com.baidaidai.rootless_store.domain.plugin.model.PluginRunModel
 import com.baidaidai.rootless_store.domain.plugin.model.PluginSource
 import com.baidaidai.rootless_store.domain.plugin.model.PluginState
 
@@ -32,36 +32,7 @@ data class PluginInfoEntity(
     val requiredEnvironment: HosterOverallStatus,
     val state: PluginState,
     val source: PluginSource,
-    val entryPoint: String
-){
-    companion object {
-
-        /**
-         * Create a PluginInfoEntity from PluginManiFest.
-         *
-         * This is the single source of truth for mapping
-         * manifest data into database entity.
-         */
-        fun fromPluginManifestRoom(
-            pluginManifestRoom: PluginManifestRoom
-        ): PluginInfoEntity =
-            PluginInfoEntity(
-                pluginID = pluginManifestRoom.pluginID,
-
-                // Basic Infos
-                installedVersion = pluginManifestRoom.installedVersion,
-                pluginRenderingName = pluginManifestRoom.pluginRenderingName,
-                pluginPackageName = pluginManifestRoom.pluginPackageName,
-                iconURI = pluginManifestRoom.iconURI,
-                author = pluginManifestRoom.author,
-                pluginDescription = pluginManifestRoom.pluginDescription,
-
-                // Runtime Infos
-                enabled = false,
-                requiredEnvironment = pluginManifestRoom.requiredEnvironment,
-                state = pluginManifestRoom.state,
-                source = pluginManifestRoom.source,
-                entryPoint = pluginManifestRoom.entryPoint
-            )
-    }
-}
+    val entryPoint: String,
+    val pluginRunModel: PluginRunModel,
+    val webUIEntryPoint: String?
+)

--- a/app/src/main/java/com/baidaidai/rootless_store/data/plugin/mapper/PluginMapper.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/data/plugin/mapper/PluginMapper.kt
@@ -21,7 +21,9 @@ object PluginMapper {
             requiredEnvironment = requiredEnvironment,
             state = PluginState.Great,
             source = PluginSource.Local,
-            entryPoint = entryPoint
+            entryPoint = entryPoint,
+            pluginRunModel = pluginRunModel,
+            webUIEntryPoint = webUIEntryPoint
         )
     }
     fun PluginManifestRemote.toPluginInfoEntity(): PluginInfoEntity {
@@ -37,7 +39,9 @@ object PluginMapper {
             requiredEnvironment = requiredEnvironment,
             state = PluginState.Great,
             source = PluginSource.Official,
-            entryPoint = entryPoint
+            entryPoint = entryPoint,
+            pluginRunModel = pluginRunModel,
+            webUIEntryPoint = webUIEntryPoint,
         )
     }
 

--- a/app/src/main/java/com/baidaidai/rootless_store/domain/plugin/manifest/PluginManifest.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/domain/plugin/manifest/PluginManifest.kt
@@ -102,16 +102,57 @@ sealed interface PluginManifest: ModuleManifestCollection {
      */
     val requiredEnvironment: HosterOverallStatus
 
+    /**
+     * The runtime model used when executing the plugin.
+     *
+     * Recommendations:
+     * - Choose `OneTime` for scripts that produce no output, run once, or emit only a small amount of logs.
+     * - Choose `Daemon` for long-running tasks, continuous output, or anything that needs persistent monitoring.
+     *
+     * Important:
+     * - If the plugin is not clearly one-shot, you must choose `Daemon`.
+     */
+    val pluginRunModel: PluginRunModel
+
     val entryPoint: String
+
+    /**
+     * The optional Web UI entry point of the plugin.
+     *
+     * We follow the KernelSU-style `webroot` convention, while still allowing
+     * plugin authors to choose a custom layout when needed.
+     *
+     * Usage:
+     * - Set this to `null` if the plugin does not provide a Web UI.
+     * - If the plugin provides a Web UI, set this to the relative path of
+     *   `index.html` from the plugin package root.
+     *
+     * Example:
+     * - `null`
+     * - `"webroot/index.html"`
+     * - `"ui/index.html"`
+     */
+    val webUIEntryPoint: String?
 
     // Runtime state such as `enabled`, `state`, `source` should NOT belong here:
     // - enabled: Boolean
     // - state: PluginState
     // - source: PluginSource
-    interface PluginManifestLocal: PluginManifest
+    interface PluginManifestLocal: PluginManifest {
+
+        /**
+         * Additional files that should be restored/marked as executable after extraction.
+         *
+         * Android packaging/extraction may not preserve Unix executable bits,
+         * so the host should chmod these paths before running the plugin.
+         *
+         * Paths are relative to the plugin package root.
+         */
+        val executableFiles: List<String>?
+
+    }
     interface PluginManifestRemote: PluginManifest {
         val pluginURI: String
-        val pluginRunModel: PluginRunModel
     }
     interface PluginManifestRoom: PluginManifest {
         val enabled: Boolean

--- a/app/src/main/java/com/baidaidai/rootless_store/domain/plugin/manifest/PluginManifestLocal.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/domain/plugin/manifest/PluginManifestLocal.kt
@@ -1,7 +1,6 @@
 package com.baidaidai.rootless_store.domain.plugin.manifest
 
-import com.baidaidai.rootless_store.domain.plugin.model.PluginSource
-import com.baidaidai.rootless_store.domain.plugin.model.PluginState
+import com.baidaidai.rootless_store.domain.plugin.model.PluginRunModel
 import com.baidaidai.rootless_store.domain.status.model.HosterOverallStatus
 import kotlinx.serialization.Serializable
 
@@ -30,7 +29,10 @@ data class PluginManifestLocal(
     override val author: String,
     override val pluginDescription: String,
     override val requiredEnvironment: HosterOverallStatus,
-    override val entryPoint: String
+    override val entryPoint: String,
+    override val pluginRunModel: PluginRunModel,
+    override val webUIEntryPoint: String? = null,
+    override val executableFiles: List<String>? = null
 ): PluginManifest.PluginManifestLocal{
     companion object {
         val _testOnly_ = PluginManifestLocal(
@@ -42,23 +44,8 @@ data class PluginManifestLocal(
             author = "Rootless Store(Creater. Bai)",
             requiredEnvironment = HosterOverallStatus.LIMITED,
             pluginDescription = "Tested by Creater. Bai",
-            entryPoint = "./index.sh"
-        )
-    }
-    fun toManifestRoom(): PluginManifestRoom{
-        return PluginManifestRoom(
-            enabled = false,
-            state = PluginState.Great,
-            source = PluginSource.Local,
-            installedVersion = installedVersion,
-            pluginRenderingName = pluginRenderingName,
-            pluginPackageName = pluginPackageName,
-            pluginID = pluginID,
-            iconURI = iconURI,
-            author = author,
-            pluginDescription = pluginDescription,
-            requiredEnvironment = requiredEnvironment,
-            entryPoint = entryPoint
+            entryPoint = "./index.sh",
+            pluginRunModel = PluginRunModel.OneTime
         )
     }
 }

--- a/app/src/main/java/com/baidaidai/rootless_store/domain/plugin/manifest/PluginManifestRemote.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/domain/plugin/manifest/PluginManifestRemote.kt
@@ -21,7 +21,8 @@ data class PluginManifestRemote(
     override val pluginURI: String,
     override val entryPoint: String,
 
-    override val pluginRunModel: PluginRunModel
+    override val pluginRunModel: PluginRunModel,
+    override val webUIEntryPoint: String? = null
 ): PluginManifest.PluginManifestRemote {
     companion object {
         val _testOnly_ = PluginManifestRemote(

--- a/app/src/main/java/com/baidaidai/rootless_store/domain/plugin/manifest/PluginManifestRoom.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/domain/plugin/manifest/PluginManifestRoom.kt
@@ -1,5 +1,6 @@
 package com.baidaidai.rootless_store.domain.plugin.manifest
 
+import com.baidaidai.rootless_store.domain.plugin.model.PluginRunModel
 import com.baidaidai.rootless_store.domain.plugin.model.PluginSource
 import com.baidaidai.rootless_store.domain.plugin.model.PluginState
 import com.baidaidai.rootless_store.domain.status.model.HosterOverallStatus
@@ -16,8 +17,11 @@ data class PluginManifestRoom(
     override val author: String,
     override val pluginDescription: String,
     override val requiredEnvironment: HosterOverallStatus,
-    override val entryPoint: String
+    override val entryPoint: String,
+    override val pluginRunModel: PluginRunModel,
+    override val webUIEntryPoint: String? = null
 ): PluginManifest.PluginManifestRoom{
+
     companion object {
         val _testOnly_ = PluginManifestRoom(
             installedVersion = "x.x.x",
@@ -31,7 +35,8 @@ data class PluginManifestRoom(
             enabled = false,
             state = PluginState.PermissionProblems,
             source = PluginSource.Local,
-            entryPoint = "./index.sh"
+            entryPoint = "./index.sh",
+            pluginRunModel = PluginRunModel.OneTime
         )
     }
 }


### PR DESCRIPTION
Add plugin run model and web UI entry point to the shared plugin manifest. Persist the new fields in plugin info storage and set CodeBrick generated plugins to one-time mode.