### PR TITLE
fix(release): Correct v2.0.0 alpha release notes

### DIFF
--- a/asset/markdown/release/v2.0.0-alpha.md
+++ b/asset/markdown/release/v2.0.0-alpha.md
@@ -1,16 +1,16 @@
-# Rootless Store 2.0 正式发布
+# Rootless Store 2.0 Alpha 先行发布
 
-Welcome to Rootless Store v2.0.0!
+Welcome to Rootless Store v2.0.0-alpha!
 
-Rootless Store 2.0 is a major milestone release. This version is not just a normal feature update: it rebuilds the product direction around plugins, Code Brick automation, execution contexts, and daily Android workflow integration.
+Rootless Store v2.0.0-alpha is the first public Alpha release of the 2.0 series. This version is not a final stable release. It is prepared for early users and developers who want to try the new 2.0 workflow in advance, verify plugin behavior, and help us identify issues before the final 2.0 release.
 
-欢迎来到 Rootless Store v2.0.0！
+欢迎来到 Rootless Store v2.0.0-alpha！
 
-Rootless Store 2.0 是一个重要的里程碑版本。这不是一次普通功能更新，而是围绕插件、Code Brick 自动化、执行环境选择，以及 Android 日常工作流整合进行的一次大版本升级。
+Rootless Store v2.0.0-alpha 是 2.0 系列的第一个公开 Alpha 先行版本。这个版本并不是最终稳定版，而是面向希望提前体验 2.0 新工作流、验证插件表现，并帮助我们在正式版前发现问题的早期用户和开发者。
 
 ---
 
-### What's New in v2.0.0
+### What's New in v2.0.0-alpha
 
 * **Code Brick Becomes a Real Automation Workflow**:
     * Code Brick is no longer only a place to save reusable shell snippets.
@@ -23,9 +23,9 @@ Rootless Store 2.0 是一个重要的里程碑版本。这不是一次普通功�
     * This makes it easier to distribute small automations without requiring users to copy every command by hand.
 
 * **Convert Code Brick Into Plugin**:
-    * A Code Brick can now be promoted into a full plugin when it becomes stable or important enough.
+    * A Code Brick can now be promoted into a plugin when it becomes stable or important enough.
     * Users can start from a quick script, test it, refine it, and then turn it into a reusable plugin.
-    * Rootless Store now better connects lightweight personal automation with the full plugin ecosystem.
+    * Rootless Store now better connects lightweight personal automation with the plugin workflow.
 
 * **Plugin Execution Bug Fixes**:
     * Fixed cases where the selected execution context did not take effect correctly.
@@ -42,9 +42,9 @@ Rootless Store 2.0 是一个重要的里程碑版本。这不是一次普通功�
     * Plugins that enable it can run closer to native Shell behavior when supported.
     * This helps avoid failures caused by forced permission downgrades, especially for plugins that are designed to work as direct Shell tools.
 
-### v2.0.0 更新内容
+### v2.0.0-alpha 更新内容
 
-* **Code Brick 正式成为自动化工作流**:
+* **Code Brick 正式进入自动化工作流**:
     * Code Brick 不再只是保存 Shell 片段的地方。
     * 用户现在可以创建快捷自动化，并将其绑定到 Android 快捷设置磁贴中，在应用外也能直接触发。
     * 这让日常操作更快、更轻，也更接近系统级快捷入口的体验。
@@ -55,9 +55,9 @@ Rootless Store 2.0 是一个重要的里程碑版本。这不是一次普通功�
     * 这让小型自动化更容易分发，不需要用户手动复制每一段命令。
 
 * **Code Brick 可以升级为插件**:
-    * 当一个 Code Brick 足够稳定、足够重要时，现在可以将它转换为正式插件。
+    * 当一个 Code Brick 足够稳定、足够重要时，现在可以将它转换为插件。
     * 用户可以从一个快捷脚本开始，测试、打磨，然后逐步升级成可复用插件。
-    * Rootless Store 现在把个人轻量自动化和完整插件生态连接得更自然。
+    * Rootless Store 现在把个人轻量自动化和插件工作流连接得更自然。
 
 * **插件执行 Bug 修复**:
     * 修复了部分情况下执行环境选择不生效的问题。
@@ -79,29 +79,29 @@ Rootless Store 2.0 是一个重要的里程碑版本。这不是一次普通功�
 ### Migration & Compatibility Notice
 
 > [!WARNING]
-> Rootless Store 2.0 includes breaking changes to the plugin ecosystem and local data foundation. Automatic migration from the 1.x series is not recommended.
+> Rootless Store v2.0.0-alpha includes breaking changes to the plugin ecosystem and local data foundation. It is not recommended to use it as a direct production upgrade from the 1.x series.
 
-If you still have important plugins or environment packages in 1.x, please export and back them up first, preferably through the v1.6.0 migration release. Some older plugins may also need to be adjusted before they can fully match the 2.0 workflow.
+If you still have important plugins or environment packages in 1.x, please export and back them up first, preferably through the v1.6.0 migration release. Some older plugins may need to be adjusted before they can fully match the 2.0 workflow.
 
-For users who want the cleanest 2.0 experience, installing v2.0.0 as a fresh major version is recommended. Future 2.x versions will continue improving plugin compatibility, execution feedback, Code Brick sharing, and the developer experience.
+For users who want to try this Alpha release, a clean installation or a dedicated test environment is recommended. Future 2.x versions may continue changing compatibility behavior, execution feedback, Code Brick sharing, and the developer experience.
 
 ### 迁移与兼容提醒
 
 > [!WARNING]
-> Rootless Store 2.0 对插件生态和本地数据基础进行了破坏性调整，因此不建议期待从 1.x 系列无感自动迁移。
+> Rootless Store v2.0.0-alpha 对插件生态和本地数据基础进行了破坏性调整，不建议将它作为从 1.x 系列直接升级的生产版本使用。
 
-如果你在 1.x 中仍有重要插件或环境包，请先完成导出和备份，推荐通过 v1.6.0 迁移版本提前处理。部分旧插件也可能需要调整后，才能完全适配 2.0 的新工作流。
+如果你在 1.x 中仍有重要插件或环境包，请先完成导出和备份，推荐通过 v1.6.0 迁移版本提前处理。部分旧插件可能需要调整后，才能完全适配 2.0 的新工作流。
 
-如果你想获得最干净的 2.0 体验，建议将 v2.0.0 作为一个新的大版本重新开始使用。后续 2.x 版本会继续完善插件兼容性、执行反馈、Code Brick 分享，以及开发者体验。
+如果你想体验这个 Alpha 版本，建议使用干净安装或专门的测试环境。后续 2.x 版本仍可能继续调整兼容性行为、执行反馈、Code Brick 分享，以及开发者体验。
 
 ---
 
 ### Thanks
 
-Thank you for following Rootless Store through the 1.x series and into 2.0.
+Thank you for testing Rootless Store v2.0.0-alpha and helping shape the next major version.
 
-Rootless Store 2.0 is a new starting point. It is built for users who want lower barriers, for developers who want a clearer plugin system, and for everyone who believes Android should have a more open, approachable automation ecosystem.
+Rootless Store 2.0 is still moving toward its final form. This Alpha release is a starting point for testing, feedback, and compatibility verification before the stable 2.0 release.
 
-感谢你从 1.x 一路关注 Rootless Store，并来到 2.0。
+感谢你测试 Rootless Store v2.0.0-alpha，并帮助我们共同打磨下一个大版本。
 
-Rootless Store 2.0 是一个新的起点。它面向希望降低门槛的用户，面向希望拥有更清晰插件体系的开发者，也面向所有相信 Android 应该拥有更开放、更易接近自动化生态的人。
+Rootless Store 2.0 仍在走向最终形态。这个 Alpha 版本是正式稳定版到来前，用于测试、反馈和兼容性验证的起点。


### PR DESCRIPTION
Rename the v2.0.0 release note to v2.0.0-alpha.
Update the release copy to describe the Alpha testing scope.