### PR TITLE
fix(ui): Use run icon for tiles and notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -56,7 +56,7 @@
         <service
             android:name=".service.tile.CustomTileService_0"
             android:label="Reverse Tile 0"
-            android:icon="@drawable/ic_launcher_foreground"
+            android:icon="@drawable/material_symbols_directions_run"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
             android:exported="true">
             <intent-filter>
@@ -69,7 +69,7 @@
         <service
             android:name=".service.tile.CustomTileService_1"
             android:label="Reverse Tile 1"
-            android:icon="@drawable/ic_launcher_foreground"
+            android:icon="@drawable/material_symbols_directions_run"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
             android:exported="true">
             <intent-filter>
@@ -82,7 +82,7 @@
         <service
             android:name=".service.tile.CustomTileService_2"
             android:label="Reverse Tile 2"
-            android:icon="@drawable/ic_launcher_foreground"
+            android:icon="@drawable/material_symbols_directions_run"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
             android:exported="true">
             <intent-filter>
@@ -95,7 +95,7 @@
         <service
             android:name=".service.tile.CustomTileService_3"
             android:label="Reverse Tile 3"
-            android:icon="@drawable/ic_launcher_foreground"
+            android:icon="@drawable/material_symbols_directions_run"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
             android:exported="true">
             <intent-filter>
@@ -108,7 +108,7 @@
         <service
             android:name=".service.tile.CustomTileService_4"
             android:label="Reverse Tile 4"
-            android:icon="@drawable/ic_launcher_foreground"
+            android:icon="@drawable/material_symbols_directions_run"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/baidaidai/rootless_store/data/notification/gateway/NotificationManagerGatewayImpl.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/data/notification/gateway/NotificationManagerGatewayImpl.kt
@@ -43,7 +43,7 @@ class NotificationManagerGatewayImpl @Inject constructor(
             return
         }
         val notification = NotificationCompat.Builder(context, channel_id)
-            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setSmallIcon(R.drawable.material_symbols_directions_run)
             .setContentTitle(title)
             .setContentText(message)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)

--- a/app/src/main/res/drawable/material_symbols_directions_run.xml
+++ b/app/src/main/res/drawable/material_symbols_directions_run.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960"
+    android:tint="?attr/colorControlNormal"
+    android:autoMirrored="true">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M520,920L520,680L436,600L396,776L120,720L136,640L328,680L392,356L320,384L320,520L240,520L240,332L398,264Q433,249 449.5,244.5Q466,240 480,240Q501,240 519,251Q537,262 548,280L588,344Q614,386 658.5,413Q703,440 760,440L760,520Q694,520 636.5,492.5Q579,465 540,420L516,540L600,620L600,920L520,920ZM483.5,196.5Q460,173 460,140Q460,107 483.5,83.5Q507,60 540,60Q573,60 596.5,83.5Q620,107 620,140Q620,173 596.5,196.5Q573,220 540,220Q507,220 483.5,196.5Z"/>
+</vector>


### PR DESCRIPTION
Add a dedicated run icon for execution-related system surfaces. Use it for quick setting tiles and plugin status notifications.