### PR TITLE
fix(codebrick): Keep the floating action menu state synchronized

### DIFF
--- a/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickScreenNecessaryComponents.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickScreenNecessaryComponents.kt
@@ -8,14 +8,11 @@ import androidx.compose.material3.FloatingActionButtonMenuItem
 import androidx.compose.material3.FloatingActionButtonMenuScope
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LargeFlexibleTopAppBar
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleFloatingActionButton
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -44,25 +41,24 @@ object CodeBrickScreenNecessaryComponents {
 
     @Composable
     fun CodeBrickScreenFloatingButton(
+        buttonMenuExpandStatus: Boolean,
         onHandMenuItemClick: ()-> Unit = {},
         onJsonMenuItemClick: ()-> Unit = {},
+        onButtonMenuClick:(Boolean)-> Unit = {}
     ) {
-
-        var buttonMenuExpandStatus by remember { mutableStateOf(false) }
 
         FloatingActionButtonMenu(
             expanded = buttonMenuExpandStatus,
             button = {
                 ToggleFloatingActionButton(
                     checked = buttonMenuExpandStatus,
-                    onCheckedChange = {
-                        buttonMenuExpandStatus = it
-                    }
+                    onCheckedChange = onButtonMenuClick
                 ) {
                     if (buttonMenuExpandStatus){
                         Icon(
                             painter = painterResource(R.drawable.outline_close_24),
-                            contentDescription = stringResource(R.string.code_brick_screen_floating_button_add_content_description)
+                            contentDescription = stringResource(R.string.code_brick_screen_floating_button_add_content_description),
+                            tint = MaterialTheme.colorScheme.onPrimary
                         )
                     }else{
                         Icon(
@@ -75,8 +71,12 @@ object CodeBrickScreenNecessaryComponents {
             modifier = Modifier
                 .offset(16.dp,16.dp)
         ) {
-            InputByJsonMenuItem { onJsonMenuItemClick() }
-            InputByHandMenuItem { onHandMenuItemClick() }
+            InputByJsonMenuItem {
+                onJsonMenuItemClick()
+            }
+            InputByHandMenuItem {
+                onHandMenuItemClick()
+            }
 
         }
     }
@@ -115,5 +115,5 @@ object CodeBrickScreenNecessaryComponents {
 @PreviewLightDark
 @Composable
 private fun _CodeBrickScreenFloatingButtonPreview_() {
-    CodeBrickScreenFloatingButton()
+    CodeBrickScreenFloatingButton(false)
 }

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/model/RootlessStoreCodeBrickViewModel.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/model/RootlessStoreCodeBrickViewModel.kt
@@ -28,6 +28,7 @@ data class CodeBrickScreenUIState(
     val brickEditorCanShow: Boolean = false,
     val executeResultCanShow: Boolean = false,
     val brickSettingCanShow: Boolean = false,
+    val buttonMenuExpandStatus: Boolean = false,
     val executeResultContent: List<String> = emptyList(),
     val handlingCodeBrickConfig: CodeBrickConfig = CodeBrickConfig(unixTimeStamp = 1L,"", HosterOverallStatus.LIMITED,"")
 )
@@ -91,6 +92,15 @@ class RootlessStoreCodeBrickViewModel @Inject constructor(
         _codeBrickScreenUIState.update {
             it.copy(
                 executeResultCanShow = showStatus
+            )
+        }
+    }
+    fun changeButtonMenuStatus(
+        showStatus: Boolean = false
+    ){
+        _codeBrickScreenUIState.update {
+            it.copy(
+                buttonMenuExpandStatus = showStatus
             )
         }
     }

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/screens/CodeBrickScreen.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/screens/CodeBrickScreen.kt
@@ -1,5 +1,7 @@
 package com.baidaidai.rootless_store.ui.screens
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,6 +12,7 @@ import androidx.compose.foundation.lazy.staggeredgrid.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -22,7 +25,8 @@ import com.baidaidai.rootless_store.ui.model.RootlessStoreCodeBrickViewModel
 @Composable
 fun CodeBrickScreen(
     contentPaddingValues: PaddingValues,
-    codeBrickViewModel: RootlessStoreCodeBrickViewModel = hiltViewModel<RootlessStoreCodeBrickViewModel>()
+    codeBrickViewModel: RootlessStoreCodeBrickViewModel = hiltViewModel<RootlessStoreCodeBrickViewModel>(),
+    onBackgroundClick: ()-> Unit = {}
 ){
 
     val codeBrickConfigList by codeBrickViewModel.codeBrickConfigList.collectAsState()
@@ -76,14 +80,18 @@ fun CodeBrickScreen(
     }
 
     LazyVerticalStaggeredGrid(
-        modifier = Modifier
-            .padding(contentPaddingValues)
-            .fillMaxSize()
-        ,
         verticalItemSpacing = 10.dp,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         columns = StaggeredGridCells.Fixed(2),
-        contentPadding = PaddingValues(10.dp)
+        contentPadding = PaddingValues(10.dp),
+        modifier = Modifier
+            .padding(contentPaddingValues)
+            .fillMaxSize()
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            ){ onBackgroundClick() }
+        ,
     ) {
         itemsIndexed(
             items = codeBrickConfigList

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/screens/StartScreenContainer.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/screens/StartScreenContainer.kt
@@ -252,9 +252,20 @@ fun RootlessStoreStartScreenContainer(
                 }
 
                 CodeBrickScreenKey -> {
+                    val codeBrickScreenUIState by codeBrickViewModel.codeBrickScreenUIState.collectAsState()
                     CodeBrickScreenNecessaryComponents.CodeBrickScreenFloatingButton(
-                        onHandMenuItemClick = { codeBrickViewModel.changeEditorShowStatus(true) },
-                        onJsonMenuItemClick = codeBrickViewModel::createOneCodeBrickByJson
+                        buttonMenuExpandStatus = codeBrickScreenUIState.buttonMenuExpandStatus,
+                        onHandMenuItemClick = {
+                            codeBrickViewModel.changeEditorShowStatus(true)
+                            codeBrickViewModel.changeButtonMenuStatus()
+                        },
+                        onJsonMenuItemClick = {
+                            codeBrickViewModel.createOneCodeBrickByJson()
+                            codeBrickViewModel.changeButtonMenuStatus()
+                        },
+                        onButtonMenuClick = {
+                            codeBrickViewModel.changeButtonMenuStatus(it)
+                        }
                     )
                 }
 
@@ -321,7 +332,10 @@ fun RootlessStoreStartScreenContainer(
                 entry<CodeBrickScreenKey>{
                     CodeBrickScreen(
                         contentPaddingValues = contentPadding,
-                        codeBrickViewModel = codeBrickViewModel
+                        codeBrickViewModel = codeBrickViewModel,
+                        onBackgroundClick = {
+                            codeBrickViewModel.changeButtonMenuStatus()
+                        }
                     )
                 }
                 entry<SourceScreenKey> {


### PR DESCRIPTION
Move the Code Brick action menu state into the screen ViewModel.

Close the menu after actions and background taps.

Keep the floating button icon and menu visibility synchronized.