### PR TITLE
fix(codebrick): Limit the shell editor field height

### DIFF
--- a/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickEditorContent.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickEditorContent.kt
@@ -74,7 +74,8 @@ fun CodeBrickEditorContent(
             onValueChange = onCodeBrickContentValueChange,
             label = {
                 Text(stringResource(R.string.code_brick_screen_editor_shell_script_label))
-            }
+            },
+            modifier = Modifier.heightIn(max = 300.dp),
         )
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickSettingContent.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/components/codeBrickScreen/CodeBrickSettingContent.kt
@@ -72,7 +72,8 @@ fun CodeBrickSettingContent(
             onValueChange = onCodeBrickContentValueChange,
             label = {
                 Text(stringResource(R.string.code_brick_screen_editor_shell_script_label))
-            }
+            },
+            modifier = Modifier.heightIn(max = 300.dp),
         )
 
         Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
Limit shell script fields to a maximum height of 300 dp.

Keep editor and settings dialogs usable with long code content.