### PR TITLE
chore(release): Bump Rootless Store to version 2.1.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,7 @@ android {
         minSdk = 26
         targetSdk = 28
         versionCode = 2
-        versionName = "2.1.0"
+        versionName = "2.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Rootless Store</string>
-    <string name="app_version">v2.1.0</string>
+    <string name="app_version">v2.1.1</string>
     <string name="notification_channel_id">Rootless Store Status Monitoring</string>
 
     <!-- Home Screen Strings -->

--- a/asset/markdown/release/v2.1.1.md
+++ b/asset/markdown/release/v2.1.1.md
@@ -1,0 +1,57 @@
+# 稳扎稳打的小功能更新
+
+Welcome to Rootless Store v2.1.1!
+
+Rootless Store v2.1.1 is a focused refinement update that continues improving the visual plugin experience introduced in v2.1.0.
+
+Supported WebUI plugins can now perform lightweight actions in the normal app environment and return results directly to their interfaces. This release also improves Code Brick editing, main navigation, and the version upgrade experience.
+
+欢迎来到 Rootless Store v2.1.1！
+
+Rootless Store v2.1.1 是一次稳扎稳打的小功能更新，继续完善 v2.1.0 引入的可视化插件体验。
+
+支持该能力的 WebUI 插件现在可以在普通应用环境中完成轻量操作，并将执行结果直接反馈到页面。本次更新还改善了 Code Brick 编辑体验、主导航以及版本升级过程。
+
+---
+
+### What's New in v2.1.1
+
+* **WebUI Works in More Scenarios**:
+    * Supported plugin interfaces can now perform lightweight actions in the normal App Shell environment.
+    * Features that only require ordinary permissions no longer need a higher-privilege environment to work.
+    * Execution feedback can return directly to the plugin page, making interactions more complete and responsive.
+
+* **Improved Code Brick Editing**:
+    * Long scripts no longer stretch the editor and push other options out of view.
+    * Creating and editing Code Bricks remains manageable even when the content is large.
+    * Environment selection, tile binding, and other actions are now easier to reach.
+
+* **Cleaner Navigation and Smoother Upgrades**:
+    * The unfinished Sources entry has been temporarily removed from the main navigation to avoid leading users into an incomplete workflow.
+    * Existing installed plugin information is retained during the upgrade.
+    * Users upgrading from v2.1.0 do not need to clear app data or rebuild their plugin list.
+
+### v2.1.1 更新内容
+
+* **WebUI 支持更多使用场景**:
+    * 支持该能力的插件界面现在可以在普通 App Shell 环境中完成轻量操作。
+    * 对于只需要普通权限的功能，不再需要额外准备更高权限的运行环境。
+    * 执行结果可以直接反馈到插件页面，让整个交互过程更加完整、及时。
+
+* **Code Brick 编辑体验修复**:
+    * 输入较长脚本时，编辑区域不再持续撑高并挤走其他选项。
+    * 即使内容较多，创建和编辑页面依然能够保持易用。
+    * 运行环境、快捷磁贴绑定等操作现在更容易找到和调整。
+
+* **主导航与升级体验优化**:
+    * 暂时收起了尚未完成的插件源入口，避免用户误入不完整的使用流程。
+    * 版本升级时会继续保留已有的插件信息。
+    * 从 v2.1.0 升级时，无需清除应用数据或重新整理插件列表。
+
+---
+
+### Thanks
+
+Rootless Store v2.1.1 makes the WebUI experience introduced in v2.1.0 more practical across everyday scenarios. Thank you for your continued feedback and support.
+
+Rootless Store v2.1.1 让 v2.1.0 引入的 WebUI 在更多日常场景中真正可用。感谢大家持续提供反馈与支持。


### PR DESCRIPTION
Update the build version and visible app version text. Add release notes for the latest fixes and WebUI improvements.