### PR TITLE
chore(release): Bump Rootless Store to version 2.2.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,7 @@ android {
         minSdk = 26
         targetSdk = 28
         versionCode = 2
-        versionName = "2.1.1"
+        versionName = "2.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/asset/markdown/release/v2.2.0.md
+++ b/asset/markdown/release/v2.2.0.md
@@ -1,0 +1,99 @@
+# Rootless Store v2.2.0 发布：不再只为一块屏幕而设计
+
+Welcome to Rootless Store v2.2.0!
+
+The interface no longer simply stretches a phone layout. Navigation, cards, and information are now rearranged according to the available screen space.
+
+Whether you are using a phone in landscape, a foldable device, or a tablet, Rootless Store can make better use of the display. Large screens work better, and foldables finally feel great!
+
+The new dashboards are designed around practical needs. The CPU dashboard helps users determine whether an ADB optimization produces measurable changes, while the network dashboard makes device addresses and byte flow easier to observe when hosting network services.
+
+欢迎来到 Rootless Store v2.2.0！
+
+界面不再只是简单地将手机版布局拉宽，而是会根据当前屏幕空间重新安排导航、卡片与信息。
+
+无论是手机横屏、折叠屏还是平板，Rootless Store 都能更加充分地利用眼前的这块屏幕：大屏更好用，折叠也很爽！
+
+新的看板也不是为了单纯堆砌数据。CPU 看板可以帮助用户判断 ADB 优化是否带来了可测量的变化；网络看板则让设备地址与字节流动更加直观，尤其适合需要在设备上运行网络服务的用户。
+
+---
+
+### What's New in v2.2.0
+
+* **The First Stage of Adaptive UI**:
+    * Compact screens retain the familiar bottom navigation and vertical content layout.
+    * Wider screens automatically switch to a navigation rail, leaving more space for content.
+    * On even larger displays, navigation expands into a Material Design 3 Expressive-style rail with clearer icons, labels, and page states.
+    * Cards and information are rearranged according to both width and height instead of being simply stretched.
+    * Landscape phones, foldables, and tablets can now display more useful information at the same time.
+
+* **CPU Dashboard: Make Optimization Measurable**:
+    * Wider Home layouts now include a completely new CPU dashboard.
+    * Overall CPU load, individual core activity, core count, idle status, and device uptime can be viewed at a glance.
+    * After running an optimization plugin, users can directly observe workload changes instead of judging the result only by feeling.
+    * Clear visual indicators make before-and-after comparisons easier and give every optimization more evidence behind it.
+
+* **Network Dashboard: See Every IP and Every Byte in Motion**:
+    * Rootless Store now displays as many currently available device addresses as possible across Wi-Fi, mobile networks, and VPN connections.
+    * Users with multiple network interfaces can understand their device's network presence at a glance without checking each address separately.
+    * When running HTTP backends such as DDNS-GO or AList, live upload and download rates make the flow of bytes through the device easier to observe.
+    * Traffic trends help users understand whether requests are actually reaching the device and whether the service is actively transferring data.
+    * On tablets and other large displays, the adaptive dashboard can remain open as an always-on, wall-mounted status panel.
+
+* **Better Code Brick Layout on Larger Screens**:
+    * Code Brick cards now adjust their column count according to the available width.
+    * Wider screens can display more cards without making each item unnecessarily large.
+    * Browsing and managing multiple Code Bricks is now more efficient on tablets and landscape layouts.
+
+### v2.2.0 更新内容
+
+* **自适应 UI 第一阶段**:
+    * 紧凑屏幕继续保留熟悉的底部导航和纵向内容布局。
+    * 屏幕变宽后，应用会自动切换为侧边 Rail，为主要内容留出更多空间。
+    * 在更宽的屏幕上，导航会进一步升级为符合 Material Design 3 Expressive 风格的扩展 Rail，让图标、文字和当前页面状态更加清晰。
+    * 卡片与信息会同时参考屏幕宽度和高度重新排列，而不是被简单地拉伸。
+    * 手机横屏、折叠屏和平板现在可以同时展示更多真正有用的信息。
+
+* **CPU 看板：让优化效果有数可看**:
+    * 更宽的主页布局现在加入了全新的 CPU 状态看板。
+    * CPU 总体负载、各核心活动情况、核心数量、空闲状态和设备运行时间都能一目了然。
+    * 执行优化插件后，用户可以直接观察设备负载变化，而不是只凭体感判断效果。
+    * 清晰的视觉表达让优化前后的对比更加直观，也让每一次调整都更有依据。
+
+* **网络看板：看见 IP，也看见字节流动**:
+    * Rootless Store 会尽可能汇总设备当前可识别的 Wi-Fi、移动网络和 VPN 地址，让多个 IP 一眼可见。
+    * 面对多网卡、多网络环境，不必再逐个查找地址，也能快速了解设备当前的网络状态。
+    * 当设备运行 DDNS-GO、AList 等 HTTP 后端时，实时上传与下载速度可以更直观地呈现字节在设备上的流动。
+    * 通过流量趋势，可以更容易判断请求是否真正到达设备，以及服务是否正在产生数据传输。
+    * 在平板等大屏设备上，看板终于可以真正“上墙”，作为一块常驻的设备网络状态面板持续展示。
+
+* **Code Brick 大屏布局优化**:
+    * Code Brick 卡片会根据当前屏幕宽度自动调整列数。
+    * 更宽的屏幕可以同时展示更多内容，同时避免卡片被无意义地拉大。
+    * 在平板和横屏设备上，浏览与管理多个 Code Brick 会更加高效。
+
+---
+
+### Current Scope & Future Plans
+
+* This release is only the first stage of Rootless Store's adaptive interface.
+* The new CPU and network dashboards currently focus on wider layouts, while some compact-screen experiences still retain their existing design.
+* Rootless Store is currently maintained with limited personal time and energy, so this release prioritizes the Home screen, navigation, and Code Brick layout.
+* Several other interfaces have been paused for now and still use their previous layouts.
+* These screens have not been abandoned. Future releases will gradually complete the remaining adaptive interface work.
+
+### 当前范围与后续计划
+
+* 本次更新只是 Rootless Store 自适应界面的第一阶段。
+* 新 CPU 与网络看板目前主要面向较宽的屏幕布局，部分紧凑屏幕体验仍然保留现有设计。
+* Rootless Store 目前主要由个人维护，能够投入的时间和精力有限，因此这一版本优先完成了主页、导航以及 Code Brick 的布局调整。
+* 还有不少界面暂时搁置，继续沿用此前的布局。
+* 这些页面并没有被放弃，后续版本会逐步补全剩余的自适应界面。
+
+---
+
+### Thanks
+
+Thank you for your patience and continued support. v2.2.0 is not the final form of the new interface, but it establishes the direction for what comes next.
+
+感谢大家一直以来的耐心与支持。v2.2.0 还不是新界面的最终形态，但它已经为接下来的变化确定了方向。


### PR DESCRIPTION
Update the Android package version for the 2.2.0 release. Add release notes for adaptive layouts and system dashboards.