### PR TITLE
style(codebrick): Adapt the preview grid to container width

### DIFF
--- a/app/src/main/java/com/baidaidai/rootless_store/ui/screens/CodeBrickScreen.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/screens/CodeBrickScreen.kt
@@ -3,6 +3,7 @@ package com.baidaidai.rootless_store.ui.screens
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -14,9 +15,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import com.baidaidai.rootless_store.ui.adaptive.RootlessStoreWindowSize
 import com.baidaidai.rootless_store.ui.components.codeBrickScreen.CodeBrickEditor
 import com.baidaidai.rootless_store.ui.components.codeBrickScreen.CodeBrickPreviewer
 import com.baidaidai.rootless_store.ui.components.codeBrickScreen.CodeBrickExecutionResultDialog
@@ -27,7 +28,6 @@ import com.baidaidai.rootless_store.ui.model.RootlessStoreCodeBrickViewModel
 fun CodeBrickScreen(
     contentPaddingValues: PaddingValues,
     codeBrickViewModel: RootlessStoreCodeBrickViewModel = hiltViewModel<RootlessStoreCodeBrickViewModel>(),
-    rootlessStoreWindowSize: RootlessStoreWindowSize,
     onDismissCreationMenu: () -> Unit = {}
 ){
 
@@ -83,36 +83,83 @@ fun CodeBrickScreen(
     }
 
     // Brick Reactive Style Status
-    val columns = if (rootlessStoreWindowSize != RootlessStoreWindowSize.Compact){
-        StaggeredGridCells.Adaptive(200.dp)
-    }else{
-        StaggeredGridCells.Fixed(2)
-    }
 
-    LazyVerticalStaggeredGrid(
-        verticalItemSpacing = 10.dp,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        columns = columns,
-        contentPadding = PaddingValues(10.dp),
+    BoxWithConstraints(
         modifier = Modifier
-            .padding(contentPaddingValues)
             .fillMaxSize()
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null
-            ){ onDismissCreationMenu() }
+            .padding(contentPaddingValues)
     ) {
-        itemsIndexed(
-            items = codeBricks
-        ){ index ,codeBrickConfig ->
-            CodeBrickPreviewer(
-                codeBrickConfig = codeBrickConfig,
-                onExecuteClick = codeBrickViewModel::executeCodeBrick,
-                onSettingsClick = {
-                    codeBrickViewModel.showCodeBrickSettings(codeBrickConfig)
-                },
-                onDeleteClick = codeBrickViewModel::deleteCodeBrick
+
+        val resolveCodeBrickGridCount = remember(maxWidth){
+            resolveCodeBrickGridCount(
+                containerWidth = maxWidth,
+                contentPaddingValues = 10.dp
             )
         }
+
+        LazyVerticalStaggeredGrid(
+            verticalItemSpacing = 10.dp,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            columns = StaggeredGridCells.Fixed(resolveCodeBrickGridCount),
+            contentPadding = PaddingValues(10.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ){ onDismissCreationMenu() }
+        ) {
+            itemsIndexed(
+                items = codeBricks
+            ){ index ,codeBrickConfig ->
+                CodeBrickPreviewer(
+                    codeBrickConfig = codeBrickConfig,
+                    onExecuteClick = codeBrickViewModel::executeCodeBrick,
+                    onSettingsClick = {
+                        codeBrickViewModel.showCodeBrickSettings(codeBrickConfig)
+                    },
+                    onDeleteClick = codeBrickViewModel::deleteCodeBrick
+                )
+            }
+        }
     }
+}
+
+/**
+ * 按 200.dp 来算，可以吃完后剩下多少可用空间
+ * 如果 剩余空间 >= 100dp ，则应该增加一列，让所有 Preview 自己缩减来适配
+ * 如果 剩余空间 <= 100dp ，则不用变化剩下的宽度
+ */
+private fun resolveCodeBrickGridCount(
+    containerWidth: Dp,
+    contentPaddingValues: Dp,
+    minItemWidth: Dp = 150.dp,
+    maxItemWidth: Dp = 200.dp,
+    horizontalSpacing: Dp = 8.dp,
+    minColumns: Int = 2,
+    maxColumns: Int = 100
+): Int {
+    val contentWidth = containerWidth - contentPaddingValues * 2
+
+    // 先算，按200dp来能排多少列
+    val columnsAtMaxWidth = ((contentWidth + horizontalSpacing) / (maxItemWidth + horizontalSpacing))
+        .toInt()
+        .coerceAtLeast(1)
+
+    // 算算用掉的 Width 空间
+    val usedWidthAtMax =
+        maxItemWidth * columnsAtMaxWidth +
+                horizontalSpacing * (columnsAtMaxWidth - 1)
+
+    val remainingWidth = contentWidth - usedWidthAtMax
+
+    val canFitOneMoreColumn = remainingWidth >= minItemWidth + horizontalSpacing
+
+    val resolvedColumns = if (canFitOneMoreColumn) {
+        columnsAtMaxWidth + 1
+    } else {
+        columnsAtMaxWidth
+    }
+
+    return resolvedColumns.coerceIn(minColumns, maxColumns)
 }

--- a/app/src/main/java/com/baidaidai/rootless_store/ui/screens/RootlessStoreNavigationScaffold.kt
+++ b/app/src/main/java/com/baidaidai/rootless_store/ui/screens/RootlessStoreNavigationScaffold.kt
@@ -382,7 +382,6 @@ fun RootlessStoreNavigationScaffold(
                         CodeBrickScreen(
                             contentPaddingValues = contentPadding,
                             codeBrickViewModel = codeBrickViewModel,
-                            rootlessStoreWindowSize = rootlessStoreWidthWindowSize,
                             onDismissCreationMenu = {
                                 codeBrickViewModel.setCreationMenuExpanded()
                             }


### PR DESCRIPTION
Measure the available content width before building the preview grid. Choose the column count so each preview card can use the extra space.