### PR TITLE
chore(release): Bump Rootless Store to version 2.2.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,7 @@ android {
         minSdk = 26
         targetSdk = 28
         versionCode = 2
-        versionName = "2.2.0"
+        versionName = "2.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Rootless Store</string>
-    <string name="app_version">v2.2.0</string>
+    <string name="app_version">v2.2.1</string>
     <string name="notification_channel_id">Rootless Store Status Monitoring</string>
 
     <!-- Home Screen Strings -->

--- a/asset/markdown/release/v2.2.1.md
+++ b/asset/markdown/release/v2.2.1.md
@@ -1,0 +1,39 @@
+# Rootless Store v2.2.1 发布：把自适应体验再磨顺一点
+
+Welcome to Rootless Store v2.2.1!
+
+Rootless Store v2.2.1 is a focused refinement update following the adaptive interface introduced in v2.2.0.
+
+This release focuses on making Code Brick layouts more natural and balanced across different screen sizes.
+
+欢迎来到 Rootless Store v2.2.1！
+
+Rootless Store v2.2.1 是对 v2.2.0 自适应界面的一次集中打磨。
+
+本次更新主要让 Code Brick 在不同尺寸的屏幕上拥有更加自然、均衡的布局。
+
+---
+
+### What's New in v2.2.1
+
+* **A More Natural Code Brick Grid**:
+    * Code Brick now chooses a more suitable number of columns according to the actual available width.
+    * Cards make better use of the screen across portrait, landscape, foldable, and tablet layouts.
+    * Awkward empty spaces and overly loose arrangements are reduced at certain window sizes.
+    * Resizing or changing the device posture now produces a more balanced and consistent card layout.
+
+### v2.2.1 更新内容
+
+* **更加自然的 Code Brick 卡片布局**:
+    * Code Brick 现在会根据实际可用宽度，选择更合适的卡片列数。
+    * 无论是竖屏、横屏、折叠屏还是平板，卡片都能更加充分地利用当前空间。
+    * 修复了部分窗口尺寸下留白过多、排列过于松散的问题。
+    * 调整窗口或改变设备形态后，卡片布局会更加均衡、稳定。
+
+---
+
+### Thanks
+
+Thank you for continuing to use and support Rootless Store. Small refinements like these are what gradually turn adaptive design into a reliable everyday experience.
+
+感谢大家持续使用和支持 Rootless Store。正是这些看似细小的调整，让自适应设计逐渐成为真正可靠的日常体验。


### PR DESCRIPTION
Update the package and displayed version for the 2.2.1 release. Add release notes for the improved Code Brick adaptive grid.