### PR TITLE
chore(release): Bump Rootless Store to version 2.2.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,7 +39,7 @@ android {
         minSdk = 26
         targetSdk = 28
         versionCode = 2
-        versionName = "2.2.1"
+        versionName = "2.2.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Rootless Store</string>
-    <string name="app_version">v2.2.1</string>
+    <string name="app_version">v2.2.2</string>
     <string name="notification_channel_id">Rootless Store Status Monitoring</string>
 
     <!-- Home Screen Strings -->

--- a/asset/markdown/release/v2.2.2.md
+++ b/asset/markdown/release/v2.2.2.md
@@ -1,0 +1,59 @@
+# Rootless Store v2.2.2 发布：大屏不再来回跳，结果也能一键带走
+
+Welcome to Rootless Store v2.2.2!
+
+Rootless Store v2.2.2 continues the adaptive interface journey started in v2.2.0.
+
+This release brings the large-screen experience into the actual plugin workflow. Installed plugins and execution output can now stay on the same screen, while clearer empty states and copyable Code Brick results make everyday interactions more complete.
+
+欢迎来到 Rootless Store v2.2.2！
+
+Rootless Store v2.2.2 继续推进从 v2.2.0 开始的自适应界面。
+
+这一次，大屏适配真正进入了插件使用流程。插件列表与执行结果现在可以留在同一个页面中，配合更加清晰的空状态和可直接复制的 Code Brick 结果，让日常操作更加完整、顺手。
+
+---
+
+### What's New in v2.2.2
+
+* **Plugin List and Execution Output, Side by Side**:
+    * On wider screens, the plugin list and execution output can now be displayed at the same time.
+    * Selecting or starting a plugin no longer requires leaving the current plugin list.
+    * Viewing output, switching between plugins, and continuing management now feels more connected.
+    * Compact screens retain the familiar full-screen execution flow.
+
+* **Empty Screens Now Explain Themselves**:
+    * The plugin, environment, and Code Brick pages now present clear empty states when no content has been added.
+    * Icons and short messages replace screens that previously appeared blank.
+    * New users can immediately understand the current state instead of wondering whether the page failed to load.
+
+* **Copy Code Brick Results in One Tap**:
+    * Code Brick execution results can now be copied directly from the result window.
+    * The complete output is copied at once without requiring manual text selection.
+    * Results can be quickly pasted into notes, conversations, issue reports, or other tools for continued use.
+
+### v2.2.2 更新内容
+
+* **插件列表与执行结果同屏展示**:
+    * 在更宽的屏幕上，插件列表与执行结果现在可以同时显示。
+    * 选择或启动插件后，无需离开当前插件列表，就能直接查看运行输出。
+    * 查看结果、切换插件和继续管理之间的操作更加连贯。
+    * 紧凑屏幕继续保留熟悉的全屏执行流程。
+
+* **空页面现在会主动说明状态**:
+    * 当尚未添加内容时，插件、环境和 Code Brick 页面现在会展示明确的空状态。
+    * 图标与简短提示取代了此前容易让人误以为加载失败的空白页面。
+    * 初次使用或清空内容后，用户可以立刻理解当前页面的状态。
+
+* **Code Brick 结果一键复制**:
+    * Code Brick 执行结果现在可以直接从结果窗口中复制。
+    * 无需手动选择文本，一次即可复制完整输出。
+    * 结果可以快速粘贴到笔记、聊天、Issue 或其他工具中继续使用。
+
+---
+
+### Thanks
+
+Thank you for continuing to support Rootless Store. v2.2.2 makes larger screens useful not only for displaying more content, but also for completing everyday tasks with fewer steps.
+
+感谢大家持续支持 Rootless Store。v2.2.2 让大屏不只是显示得更多，也让日常操作真正少走几步。


### PR DESCRIPTION
Update the package and displayed version for the 2.2.2 release. Add release notes for adaptive plugin workflows and copyable results.