### PR TITLE
chore(gitignore): Ignore local agent files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 TODO.md
 
 ## Ai
-/skills
+/agents
 
 ## Default
 *.iml


### PR DESCRIPTION
Ignore the local agents directory instead of the old skills directory.

Keep private agent workspace files out of version control.